### PR TITLE
Enter/leave steps use PsyTimePoint and add GObject introspection to buildsystem

### DIFF
--- a/psy/psy-loop.c
+++ b/psy/psy-loop.c
@@ -10,8 +10,8 @@ typedef struct PsyLoopPrivate {
 } PsyLoopPrivate;
 
 typedef struct Iteration {
-    PsyLoop* loop;
-    gint64   timestamp;
+    PsyLoop        *loop;
+    PsyTimePoint   *timestamp;
 }Iteration;
 
 static void
@@ -19,6 +19,7 @@ iteration_free(gpointer iteration)
 {
     Iteration *iter = iteration;
     g_clear_object(&iter->loop);
+    g_clear_object(&iter->timestamp);
     g_free(iter);
 }
 
@@ -123,7 +124,7 @@ iter_cb(gpointer data)
 }
 
 static void
-psy_loop_activate(PsyStep* step, gint64 timestamp)
+psy_loop_activate(PsyStep* step, PsyTimePoint *timestamp)
 {
     PsyLoop *self = PSY_LOOP(step);
 
@@ -320,13 +321,13 @@ psy_loop_destroy(PsyLoop* loop)
  * reached, we will step out of the loop and continue the steps of the parent.
  */
 void
-psy_loop_iterate(PsyLoop* self, gint64 timestamp)
+psy_loop_iterate(PsyLoop* self, PsyTimePoint *timestamp)
 {
     GSource *source;
     Iteration *iter = g_new(Iteration, 1);
 
     iter->loop = g_object_ref(self);
-    iter->timestamp = timestamp;
+    iter->timestamp = g_object_ref(timestamp);
 
     /*
      * g_main_context_invoke and friends might recurse into stackoverflow, when

--- a/psy/psy-loop.h
+++ b/psy/psy-loop.h
@@ -28,47 +28,47 @@ struct _PsyLoopClass {
     gpointer padding[12];
 };
 
-PsyLoop*
-psy_loop_new();
+G_MODULE_EXPORT PsyLoop *
+psy_loop_new(void);
 
-PsyLoop*
+G_MODULE_EXPORT PsyLoop*
 psy_loop_new_full(gint64 index,
                   gint64 stop,
                   gint64 increment,
                   PsyLoopCondition condition
                   );
 
-void
+G_MODULE_EXPORT void
 psy_loop_destroy(PsyLoop* self);
 
-void
-psy_loop_iterate(PsyLoop* self, gint64 timestamp);
+G_MODULE_EXPORT void
+psy_loop_iterate(PsyLoop* self, PsyTimePoint *timestamp);
 
-void
+G_MODULE_EXPORT void
 psy_loop_set_index(PsyLoop* self, gint64 index);
 
-gint64
+G_MODULE_EXPORT gint64
 psy_loop_get_index(PsyLoop* self);
 
-void
+G_MODULE_EXPORT void
 psy_loop_set_stop(PsyLoop* self, gint64 stop);
 
-gint64
+G_MODULE_EXPORT gint64
 psy_loop_get_stop(PsyLoop* self);
 
-void
+G_MODULE_EXPORT void
 psy_loop_set_increment(PsyLoop* self, gint64 increment);
 
-gint64
+G_MODULE_EXPORT gint64
 psy_loop_get_increment(PsyLoop* self);
 
-void
+G_MODULE_EXPORT void
 psy_loop_set_condition(PsyLoop* self, PsyLoopCondition condition);
 
-PsyLoopCondition
+G_MODULE_EXPORT PsyLoopCondition
 psy_loop_get_condition(PsyLoop* self);
 
-gboolean
+G_MODULE_EXPORT gboolean
 psy_loop_test(PsyLoop* self);
 
 G_END_DECLS

--- a/psy/psy-step.h
+++ b/psy/psy-step.h
@@ -3,6 +3,7 @@
 #define PSY_STEP_H
 
 #include <glib-object.h>
+#include "psy-time-point.h"
 
 G_BEGIN_DECLS
 
@@ -12,21 +13,21 @@ G_DECLARE_DERIVABLE_TYPE(PsyStep, psy_step, PSY, STEP, GObject)
 struct _PsyStepClass {
     GObjectClass parent;
 
-    void (*on_enter)   (PsyStep* self, gint64 timestamp);
+    void (*on_enter)   (PsyStep* self, PsyTimePoint* timestamp);
 
-    void (*on_leave)   (PsyStep* self, gint64 timestamp);
+    void (*on_leave)   (PsyStep* self, PsyTimePoint* timestamp);
 
-    void (*activate)   (PsyStep* self, gint64 timestamp);
-    void (*deactivate) (PsyStep* self, gint64 timestamp);
+    void (*activate)   (PsyStep* self, PsyTimePoint* timestamp);
+    void (*deactivate) (PsyStep* self, PsyTimePoint* timestamp);
 
     gpointer padding[12];
 };
 
 void
-psy_step_enter(PsyStep* self, gint64 tstamp);
+psy_step_enter(PsyStep* self, PsyTimePoint* tstamp);
 
 void
-psy_step_leave(PsyStep* self, gint64 tstamp);
+psy_step_leave(PsyStep* self, PsyTimePoint* tstamp);
 
 void
 psy_step_set_parent(PsyStep* self, PsyStep* parent);
@@ -35,7 +36,7 @@ PsyStep*
 psy_step_get_parent(PsyStep* self);
 
 void
-psy_step_activate(PsyStep* self, gint64 timestamp);
+psy_step_activate(PsyStep* self, PsyTimePoint* timestamp);
 
 GMainContext*
 psy_step_get_main_context(PsyStep* self);

--- a/psy/psy-stepping-stones.c
+++ b/psy/psy-stepping-stones.c
@@ -1,6 +1,14 @@
 
 #include "psy-stepping-stones.h"
 
+/**
+ * PsySteppingStones:
+ *
+ * The `PsySteppingStones` object is a `PsyStep` instance that may
+ * be used to contain substeps. The contained steps may be processed in
+ * order, by index or by the name of the steps.
+ */
+
 typedef struct _PsySteppingStonesPrivate {
     GPtrArray  *steps;
     GHashTable *step_table;
@@ -115,7 +123,7 @@ psy_stepping_stones_init(PsySteppingStones* self)
 }
 
 static void
-stepping_stones_activate(PsyStep* step, gint64 timestamp)
+stepping_stones_activate(PsyStep* step, PsyTimePoint *timestamp)
 {
     PsySteppingStones *self = PSY_STEPPING_STONES(step);
     PsySteppingStonesPrivate* priv = psy_stepping_stones_get_instance_private(
@@ -163,7 +171,12 @@ psy_stepping_stones_class_init(PsySteppingStonesClass* klass)
 }
 
 /* ************** public functions *********************/
-
+/**
+ * psy_stepping_stones_new:(constructor)
+ *
+ * Creates a new `PsySteppingStones` object
+ * Returns: a new `PsySteppingStones` instance
+ */
 PsySteppingStones*
 psy_stepping_stones_new()
 {
@@ -177,6 +190,15 @@ psy_stepping_stones_destroy(PsySteppingStones* self)
     g_object_unref(self);
 }
 
+/**
+ * psy_stepping_stones_add_step:(constructor)
+ * @self: The `PsySteppingStones` instance to which a `PsyStep` @step
+ * @step: The `PsyStep` to add to @self
+ *
+ * To a `PsySteppingStones` multiple steps/stones may be added when
+ * added like this, this allows to step through them in the order
+ * in which the are added.
+ */
 void
 psy_stepping_stones_add_step(PsySteppingStones* self, PsyStep* step)
 {
@@ -190,6 +212,14 @@ psy_stepping_stones_add_step(PsySteppingStones* self, PsyStep* step)
     psy_step_set_parent(step, PSY_STEP(self));
 }
 
+/**
+ * psy_stepping_stones_add_step_by_name:
+ * @self: The instance self
+ * @name: The name for the step to add this name may be used to jump back
+ * or skip subsequent steps. The name should be unique.
+ * @step: The step to add
+ * @error: optional errors may be returned here.
+ */
 void
 psy_stepping_stones_add_step_by_name(PsySteppingStones *self,
                                      const gchar       *name,
@@ -218,6 +248,13 @@ psy_stepping_stones_add_step_by_name(PsySteppingStones *self,
     psy_stepping_stones_add_step(self, step);
 }
 
+/**
+ * psy_stepping_stones_activate_next_by_index:
+ * @self:
+ * @index: The index of the next step to be activated. It should be
+ *         less than the number of steps added to this step.
+ * @error:(out): An optional error may be returned here.
+ */
 void
 psy_stepping_stones_activate_next_by_index(PsySteppingStones  *self,
                                            guint               index,
@@ -243,12 +280,11 @@ psy_stepping_stones_activate_next_by_index(PsySteppingStones  *self,
 
 /**
  * psy_stepping_stones_activate_next_by_name:
+ * @self: an `PsySteppingStones` instance
+ * @name: A name of another other `PsyStep` in PsySteppingStones:steps
+ * @error: An error may be returned here
  *
  * Allows for activating the next step.
- *
- * self: an `PsySteppingStones` instance
- * name: A name of another other `PsyStep` in PsySteppingStones:steps
- * error: An error may be returned here
  */
 void
 psy_stepping_stones_activate_next_by_name(PsySteppingStones *self,
@@ -282,8 +318,7 @@ psy_stepping_stones_activate_next_by_name(PsySteppingStones *self,
 
 /**
  * psy_stepping_stones_get_num_steps:
- *
- * self: An `PsySteppingStones` instance self
+ * @self: An `PsySteppingStones` instance self
  *
  * Returns::The number of steps in the stepping stones.
  */

--- a/psy/psy-stepping-stones.h
+++ b/psy/psy-stepping-stones.h
@@ -9,7 +9,7 @@ G_BEGIN_DECLS
 
 #define PSY_STEPPING_STONES_ERROR psy_stepping_stones_error_quark()
 G_MODULE_EXPORT GQuark
-psy_stepping_stones_error_quark();
+psy_stepping_stones_error_quark(void);
 
 typedef enum {
     PSY_STEPPING_STONES_ERROR_KEY_EXISTS,
@@ -28,32 +28,32 @@ struct _PsySteppingStonesClass {
     gpointer padding[12];
 };
 
-PsySteppingStones*
-psy_stepping_stones_new();
+G_MODULE_EXPORT PsySteppingStones*
+psy_stepping_stones_new(void);
 
-void
-psy_stepping_stones_destroy();
+G_MODULE_EXPORT void
+psy_stepping_stones_destroy(PsySteppingStones* self);
 
-void
+G_MODULE_EXPORT void
 psy_stepping_stones_add_step(PsySteppingStones* self, PsyStep* step);
 
-void
+G_MODULE_EXPORT void
 psy_stepping_stones_add_step_by_name(PsySteppingStones *self,
                                      const gchar       *name,
                                      PsyStep           *step,
                                      GError           **error);
 
-void
+G_MODULE_EXPORT void
 psy_stepping_stones_activate_next_by_index(PsySteppingStones  *self,
                                            guint               index,
                                            GError            **error);
 
-void
+G_MODULE_EXPORT void
 psy_stepping_stones_activate_next_by_name(PsySteppingStones *self,
                                           const gchar       *name,
                                           GError           **error);
 
-guint
+G_MODULE_EXPORT guint
 psy_stepping_stones_get_num_steps(PsySteppingStones* self);
 
 G_END_DECLS


### PR DESCRIPTION
Previously, the steps used a gint64 value as timepoint. This pull request replaces the guint by PsyTimePoints. To timepoint one can add a PsyDuration, which allows for clear and correct timing.