### PR TITLE
Gtk as meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,9 +3,9 @@ project('libpsy',
     version : '0.1',
     default_options : [
         'warning_level=3',
-        'werror=true',
+#        'werror=true',
         'buildtype=debugoptimized',
-        'c_std=c11'
+        'c_std=gnu11' # this makes it easier to compile sub projects
     ],
     license : 'MIT'
 )
@@ -19,25 +19,27 @@ glib_req = '>=2.66.0' # based on what gtk requires august 2022
 gtk_req = '>4.0' # based on what gtk requires august 2022
 
 glib_dep = dependency(
-    'glib',
+    'glib-2.0',
     version: glib_req,
-    fallback: ['glib', 'glib_dep'],
+    fallback: ['glib', 'libglib_dep'],
     default_options : [
         'tests=false'
     ]
 )
+
 gobject_dep = dependency(
-    'glib',
-    version: glib_dep,
-    fallback: ['glib', 'gobject_dep'],
+    'gobject-2.0',
+    version: glib_req,
+    fallback: ['glib', 'libgobject_dep'],
     default_options : [
-        'tests=false' # currently some test fails
+        'tests=false'
     ]
 )
+
 gio_dep = dependency(
-    'glib',
-    version: glib_dep,
-    fallback: ['glib', 'gio_dep'],
+    'gio-2.0',
+    version: glib_req,
+    fallback: ['glib', 'libgio_dep'],
     default_options : [
         'tests=false'
     ]
@@ -48,8 +50,11 @@ gtk_dep = dependency(
     version : gtk_req,
     fallback:['gtk', 'gtk_dep'],
     default_options:[
+        'warning_level=0',          # match gtk's internal warning level
+#        'werror=false',             # No point in stopping if gtk-build fails on warnings
         'wayland-backend=false',    # difficult to build on 20.04: wayland-protocols found: NO found 1.20 but need: '>= 1.25'
-        'media-gstreamer=disabled'  # idem 
+        'media-gstreamer=disabled', # idem
+        'build-tests=false'
     ]
 )
 

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,45 @@ cc = meson.get_compiler('c')
 
 m_dep = cc.find_library('m', required : false)
 
-gtk_dep = dependency('gtk4', version : '>4.0')
+# dependency version requirements
+glib_req = '>=2.66.0' # based on what gtk requires august 2022
+gtk_req = '>4.0' # based on what gtk requires august 2022
+
+glib_dep = dependency(
+    'glib',
+    version: glib_req,
+    fallback: ['glib', 'glib_dep'],
+    default_options : [
+        'tests=false'
+    ]
+)
+gobject_dep = dependency(
+    'glib',
+    version: glib_dep,
+    fallback: ['glib', 'gobject_dep'],
+    default_options : [
+        'tests=false' # currently some test fails
+    ]
+)
+gio_dep = dependency(
+    'glib',
+    version: glib_dep,
+    fallback: ['glib', 'gio_dep'],
+    default_options : [
+        'tests=false'
+    ]
+)
+
+gtk_dep = dependency(
+    'gtk4',
+    version : gtk_req,
+    fallback:['gtk', 'gtk_dep'],
+    default_options:[
+        'wayland-backend=false',    # difficult to build on 20.04: wayland-protocols found: NO found 1.20 but need: '>= 1.25'
+        'media-gstreamer=disabled'  # idem 
+    ]
+)
+
 epoxy_dep = dependency('epoxy', version : '>1.0')
 
 exe = executable(

--- a/psy/meson.build
+++ b/psy/meson.build
@@ -110,7 +110,7 @@ libpsy = library (
 libpsy_dep = declare_dependency(
     link_with : libpsy,
     include_directories : [libpsy_incdirs, config_incdirs],
-    dependencies : [gtk_dep, epoxy_dep, m_dep]
+    dependencies : [glib_dep, gobject_dep, gtk_dep, epoxy_dep, m_dep]
 )
 
 gir = gnome.generate_gir(

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,3 @@
+
+# ignore subdirectories
+*/

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory=glib
+url=https://gitlab.gnome.org/GNOME/glib.git
+revision=main
+depth=1

--- a/subprojects/gtk.wrap
+++ b/subprojects/gtk.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://gitlab.gnome.org/GNOME/gtk.git
+revision = main
+depth = 1


### PR DESCRIPTION
Previously I've been using gtk-4 from an separate build on my pc. Then gtk would be installed under /opt/gtk/, this resulted in the need to specify all kind of paths in order to run the binaries. PKG_CONFIG_PATH, LD_LIBRARY_PATH. Since Gtk is now a dependency from a subproject it easier to get started with PsyLib. 

This pull request allows to use gtk as a meson subproject.

Additionally this, might make it easier to step through the code of glib/gobject etc.