### PR TITLE
Feature/gl cicle drawing

### DIFF
--- a/psy/gl/meson.build
+++ b/psy/gl/meson.build
@@ -1,14 +1,17 @@
 
 libpsy_headers += files(
+    'psy-gl-circle.h',
     'psy-gl-error.h',
     'psy-gl-fragment-shader.h',
     'psy-gl-program.h',
     'psy-gl-shader.h',
     'psy-gl-texture.h',
-    'psy-gl-vbuffer.h'
+    'psy-gl-vbuffer.h',
+    'psy-gl-vertex-shader.h'
 )
 
 libpsyfiles += files(
+    'psy-gl-circle.c',
     'psy-gl-error.c',
     'psy-gl-fragment-shader.c',
     'psy-gl-program.c',
@@ -16,5 +19,4 @@ libpsyfiles += files(
     'psy-gl-texture.c',
     'psy-gl-vbuffer.c',
     'psy-gl-vertex-shader.c',
-    'psy-gl-vertex-shader.h'
 )

--- a/psy/gl/psy-gl-circle.c
+++ b/psy/gl/psy-gl-circle.c
@@ -1,0 +1,162 @@
+
+#include <math.h>
+#include <epoxy/gl.h>
+
+#include "psy-circle.h"
+#include "psy-gl-circle.h"
+#include "psy-gl-vbuffer.h"
+#include "psy-program.h"
+#include "psy-vbuffer.h"
+#include "psy-window.h"
+
+typedef struct _PsyGlCircle {
+    PsyArtist parent_instance;
+    PsyVBuffer* vertices;
+    gfloat radius;
+} PsyGlCircle;
+
+G_DEFINE_TYPE(PsyGlCircle, psy_gl_circle, PSY_TYPE_ARTIST)
+
+//typedef enum {
+//    PROP_NULL,
+//    NUM_PROPERTIES
+//} PsyGlCircleProperty;
+//
+//static GParamSpec* gl_circle_properties[NUM_PROPERTIES];
+//
+//static void
+//psy_gl_circle_set_property(GObject        *object,
+//                           guint           prop_id,
+//                           const GValue   *value,
+//                           GParamSpec     *pspec)
+//{
+//    PsyGlCircle* self = PSY_GL_CIRCLE(object);
+//    (void) self, (void) value;
+//
+//    switch((PsyGlCircleProperty) prop_id) {
+//        default:
+//            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+//    }
+//}
+//
+//static void
+//psy_gl_circle_get_property(GObject    *object,
+//                           guint       prop_id,
+//                           GValue     *value,
+//                           GParamSpec *pspec)
+//{
+//    PsyGlCircle* self = PSY_GL_CIRCLE(object);
+//
+//    switch((PsyGlCircleProperty) prop_id) {
+//        default:
+//            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+//    }
+//}
+
+static void
+psy_gl_circle_init(PsyGlCircle *self)
+{
+    self->vertices = PSY_VBUFFER(psy_gl_vbuffer_new());
+}
+
+static void
+psy_gl_circle_dispose(GObject* object)
+{
+    PsyGlCircle* self = PSY_GL_CIRCLE(object);
+
+    g_clear_object(&self->vertices);
+
+    G_OBJECT_CLASS(psy_gl_circle_parent_class)->dispose(object);
+}
+
+static void
+psy_gl_circle_finalize(GObject* object)
+{
+    G_OBJECT_CLASS(psy_gl_circle_parent_class)->finalize(object);
+}
+
+static void
+gl_circle_draw(PsyArtist* self)
+{
+    //TODO activate a OpenGL program.
+
+    PsyGlCircle* artist = PSY_GL_CIRCLE(self);
+    PsyCircle* circle = PSY_CIRCLE(psy_artist_get_stimulus(self));
+    PsyWindow* window = psy_artist_get_window(artist);
+    PsyProgram* program = psy_window_get_shader_program(
+            window,
+            PSY_PROGRAM_UNIFORM_COLOR
+            );
+
+    gboolean store_vertices = FALSE;
+    gfloat radius;
+    GError* error = NULL;
+    
+    psy_program_use(program, &error);
+    if (error) {
+        g_critical("PsyCircle unable to use program: %s", error->message);
+        g_error_free(error);
+        error = NULL;
+    }
+
+    guint num_vertices = psy_circle_get_num_vertices(circle);
+    if (num_vertices != psy_vbuffer_get_nvertices(artist->vertices)) {
+        psy_vbuffer_set_nvertices(artist->vertices, num_vertices);
+        store_vertices = TRUE;
+    }
+
+    radius = psy_circle_get_radius(circle);
+    if (radius != artist->radius) {
+        artist->radius = radius;
+        store_vertices = TRUE;
+    }
+
+    if (store_vertices) {
+        gfloat x = 0, y = 0, z = 0;
+        float twopi = M_PI * 2.0;
+        for (gsize i = 0; i < num_vertices; i++) {
+            x = cos(i * twopi / num_vertices) * radius;
+            y = sin(i * twopi / num_vertices) * radius;
+            psy_vbuffer_set_xyz(artist->vertices, i, x, y, z);
+        }
+        psy_vbuffer_upload(artist->vertices, &error);
+        if (error) {
+            g_critical("PsyGLCircle: unable to upload vertices: %s",
+                    error->message
+                    );
+            g_error_free(error);
+        }
+    }
+    psy_vbuffer_draw_triangle_fan(artist->vertices, &error);
+}
+
+static void
+psy_gl_circle_class_init(PsyGlCircleClass* class)
+{
+    GObjectClass      *gobject_class = G_OBJECT_CLASS(class);
+    PsyArtistClass    *artist_class  = PSY_ARTIST_CLASS(class);
+
+    gobject_class->finalize     = psy_gl_circle_finalize;
+    gobject_class->dispose      = psy_gl_circle_dispose;
+
+    artist_class->draw          = gl_circle_draw;
+
+//    g_object_class_install_properties(gobject_class,
+//                                      NUM_PROPERTIES,
+//                                      gl_circle_properties);
+}
+
+/* ************ public functions ******************** */
+
+PsyGlCircle*
+psy_gl_circle_new(PsyWindow* window, PsyVisualStimulus* stimulus)
+{
+    PsyGlCircle *gl_circle = g_object_new(PSY_TYPE_GL_CIRCLE,
+          "window", window,
+          "stimulus", stimulus,
+          NULL
+          );
+
+    return gl_circle;
+}
+

--- a/psy/gl/psy-gl-circle.h
+++ b/psy/gl/psy-gl-circle.h
@@ -1,0 +1,22 @@
+#ifndef PSY_GL_CIRCLE_H
+#define PSY_GL_CIRCLE_H
+
+#include "../psy-artist.h"
+#include "../psy-circle.h"
+#include "../psy-window.h"
+
+G_BEGIN_DECLS
+
+#define PSY_TYPE_GL_CIRCLE psy_gl_circle_get_type()
+G_DECLARE_FINAL_TYPE(PsyGlCircle, psy_gl_circle, PSY, GL_CIRCLE, PsyArtist)
+
+G_MODULE_EXPORT PsyGlCircle*
+psy_gl_circle_new(PsyWindow* window, PsyVisualStimulus* stimulus);
+
+G_MODULE_EXPORT guint 
+psy_gl_circle_get_object_id(PsyGlCircle* circle);
+
+
+G_END_DECLS
+
+#endif

--- a/psy/meson.build
+++ b/psy/meson.build
@@ -32,6 +32,7 @@ libpsy_incdirs = include_directories(
 
 
 libpsy_headers = files(
+    'psy-artist.h',
     'psy-circle.h',
     'psy-clock.h',
     'psy-duration.h',
@@ -59,6 +60,7 @@ libpsy_header_private = files(
 )
 
 libpsyfiles = files (
+    'psy-artist.c',
     'psy-circle.c',
     'psy-clock.c',
     'psy-duration.c',

--- a/psy/psy-artist.c
+++ b/psy/psy-artist.c
@@ -1,0 +1,144 @@
+
+/**
+ * PsyArtist:
+ *
+ * Instances of `PsyArtist` are the objects that are finally responsible
+ * that Instances of `PsyVisualStimulus` are drawn to a canvas. The
+ * canvas will be the surface of a window, or theoretically an other type of
+ * buffer (in memory or file e.g.) To which this specific artist is drawing.
+ *
+ * The difference between a `PsyVisualStimulus` and an `PsyArtist` is that the
+ * stimulus, contains the parameters about how, when and where a stimulus should
+ * be presented, whereas an Artist is the one that is actually doing the work of
+ * converting those parameters to the drawing on the canvas. You could see it
+ * as the that a `PsyStimulus` is the set of instructions that a `PsyArtist` gets
+ * in order to draw its work of art.
+ *
+ * So a `PsyVisualStimulus` is a kind of a general description of a stimulus,
+ * whereas a `PsyArtist` knows how to transform these descriptions to the actual
+ * sculpture, painting, etc. In this analogy, One artist might be able to sculpt
+ * OpenGL style of stimuli, whereas an other artist knows Vulcan or Direct3D.
+ */
+
+#include "psy-artist.h"
+
+typedef struct _PsyArtistPrivate {
+    PsyVisualStimulus* stimulus;
+} PsyArtistPrivate;
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(
+        PsyArtist, psy_artist, G_TYPE_OBJECT
+        )
+
+typedef enum {
+    PROP_NULL,          // not used required by GObject
+    PROP_STIMULUS,
+    NUM_PROPERTIES
+} ArtistProperty;
+
+static GParamSpec*  artist_properties[NUM_PROPERTIES] = {0};
+
+static void
+artist_set_property(GObject       *object,
+                    guint          property_id,
+                    const GValue  *value,
+                    GParamSpec    *pspec
+                    )
+{
+    PsyArtist* self = PSY_ARTIST(object);
+
+    switch((ArtistProperty) property_id) {
+        case PROP_STIMULUS:
+            psy_artist_set_stimulus(self, g_value_get_object(value));
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+    }
+}
+
+static void
+artist_get_property(GObject       *object,
+                    guint          property_id,
+                    GValue        *value,
+                    GParamSpec    *pspec
+                    )
+{
+    PsyArtist* self = PSY_ARTIST(object);
+    PsyArtistPrivate* priv = psy_artist_get_instance_private(self);
+
+    switch((ArtistProperty) property_id) {
+        case PROP_STIMULUS:
+            g_value_set_object(value, priv->stimulus);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+    }
+}
+
+static void
+psy_artist_init(PsyArtist* self)
+{
+    (void) self;
+}
+
+static void
+psy_artist_class_init(PsyArtistClass* klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->get_property = artist_get_property;
+    object_class->set_property = artist_set_property;
+
+    /**
+     * Artist:stimulus:
+     *
+     * This is the `PsyVisualStimulus` that this instance of PsyArtist is
+     * responsible of drawing.
+     */
+    artist_properties[PROP_STIMULUS] = g_param_spec_object(
+            "stimulus",
+            "Stimulus",
+            "The stimulus that this artist is going to draw.",
+            PSY_TYPE_VISUAL_STIMULUS,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+            );
+
+    g_object_class_install_properties(
+            object_class, NUM_PROPERTIES, artist_properties 
+            );
+}
+
+/**
+ * psy_artist_set_stimulus:
+ * @self: an instance of `PsyArtist` 
+ * @stimulus: an instance of `PsyVisualStimulus`
+ *
+ * set the contained object.
+ */
+void
+psy_artist_set_stimulus(PsyArtist* self, PsyVisualStimulus* stimulus)
+{
+    g_return_if_fail(PSY_IS_ARTIST(self));
+    PsyArtistPrivate* priv = psy_artist_get_instance_private(self);
+
+    if (priv->stimulus) {
+        g_object_unref(priv->stimulus);
+    }
+
+    priv->stimulus = g_object_ref(stimulus);
+}
+
+/**
+ * psy_artist_get_stimulus:
+ * @self: An instance of `PsyArtist`
+ *
+ * Returns:(tranfer none): an instance of `PsyVisualStimulus`
+ */
+PsyVisualStimulus*
+psy_artist_get_stimulus(PsyArtist* self)
+{
+    g_return_val_if_fail(PSY_IS_ARTIST(self), NULL);
+    PsyArtistPrivate* priv = psy_artist_get_instance_private(self);
+
+    return priv->stimulus;
+}
+

--- a/psy/psy-artist.h
+++ b/psy/psy-artist.h
@@ -1,0 +1,32 @@
+
+#pragma once
+
+#include <glib-object.h>
+#include "psy-visual-stimulus.h"
+
+G_BEGIN_DECLS
+
+#define PSY_TYPE_ARTIST psy_artist_get_type()
+G_DECLARE_DERIVABLE_TYPE(
+        PsyArtist,
+        psy_artist,
+        PSY,
+        ARTIST,
+        PsyVisualStimulus
+        )
+
+typedef struct _PsyArtistClass {
+    PsyVisualStimulusClass parent;
+} PsyArtistClass;
+
+G_MODULE_EXPORT PsyArtist*
+psy_artist_new(PsyVisualStimulus* stimulus);
+
+G_MODULE_EXPORT void
+psy_artist_set_stimulus(PsyArtist* self, PsyVisualStimulus* stimulus);
+
+G_MODULE_EXPORT PsyVisualStimulus*
+psy_artist_get_stimulus(PsyArtist* self);
+
+G_END_DECLS
+

--- a/psy/psy-artist.h
+++ b/psy/psy-artist.h
@@ -17,16 +17,30 @@ G_DECLARE_DERIVABLE_TYPE(
 
 typedef struct _PsyArtistClass {
     PsyVisualStimulusClass parent;
+
+    void (*draw)(PsyVisualStimulus* stimulus);
+
+    gpointer reserved[16];
+
 } PsyArtistClass;
 
 G_MODULE_EXPORT PsyArtist*
 psy_artist_new(PsyVisualStimulus* stimulus);
 
 G_MODULE_EXPORT void
+psy_artist_set_window(PsyArtist* self, PsyWindow* window);
+
+G_MODULE_EXPORT PsyWindow*
+psy_artist_get_window(PsyArtist* self);
+
+G_MODULE_EXPORT void
 psy_artist_set_stimulus(PsyArtist* self, PsyVisualStimulus* stimulus);
 
 G_MODULE_EXPORT PsyVisualStimulus*
 psy_artist_get_stimulus(PsyArtist* self);
+
+G_MODULE_EXPORT void
+psy_artist_draw(PsyArtist* self);
 
 G_END_DECLS
 

--- a/psy/psy-circle.c
+++ b/psy/psy-circle.c
@@ -142,8 +142,8 @@ psy_circle_new_full(
     return g_object_new(
             PSY_TYPE_CIRCLE,
             "window", window,
-            "x", x,
-            "y", y,
+//            "x", x,
+//            "y", y,
             "radius", radius,
             "num_vertices", num_vertices,
             NULL);

--- a/psy/psy-program.h
+++ b/psy/psy-program.h
@@ -9,6 +9,22 @@ G_BEGIN_DECLS
 #define PSY_TYPE_PROGRAM psy_program_get_type()
 G_DECLARE_DERIVABLE_TYPE(PsyProgram, psy_program, PSY, PROGRAM, GObject)
 
+/**
+ * PsyProgramType:
+ * @PSY_PROGRAM_UNIFORM_COLOR: a shader program that uses one color to color fill
+ *                             the shaded pixels.
+ * @PSY_PROGRAM_PICTURE: a shader program that uses uses a texture in order to
+ *                       shade pixels.
+ *
+ * Programs are used to do some drawing operations. Generally you can obtain
+ * these from a canvas/window on which you'd like to draw.
+ * This enumeration is use for `psy_window_get_shader_program`
+ */
+typedef enum {
+    PSY_PROGRAM_UNIFORM_COLOR,
+    PSY_PROGRAM_PICTURE,
+} PsyProgramType;
+
 
 typedef struct _PsyProgramClass {
     GObjectClass parent_class;

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -108,7 +108,7 @@ visual_stimulus_play(PsyStimulus* stimulus, PsyTimePoint* start_time)
 
     PsyWindow* window = psy_visual_stimulus_get_window(vstim);
 
-    psy_window_schedule_stimulus(window, PSY_VISUAL_STIMULUS(stimulus));
+    psy_window_schedule_stimulus(window, vstim);
 
     PSY_STIMULUS_CLASS(psy_visual_stimulus_parent_class)->play(
             stimulus, start_time

--- a/psy/psy-window.h
+++ b/psy/psy-window.h
@@ -1,8 +1,9 @@
 
 #pragma once
 
-#include "psy-time-point.h"
 #include <glib-object.h>
+#include "psy-time-point.h"
+#include "psy-program.h"
 
 G_BEGIN_DECLS
 
@@ -53,6 +54,8 @@ typedef struct _PsyWindowClass {
 
     void (*schedule_stimulus) (PsyWindow* self, PsyVisualStimulus* stimulus);
     void (*remove_stimulus) (PsyWindow* self, PsyVisualStimulus* stimulus);
+
+    PsyProgram* (*get_shader_program)(PsyWindow* window, PsyProgramType type);
     
     /*< private >*/
 
@@ -96,6 +99,8 @@ psy_window_get_frame_dur(PsyWindow* window);
 G_MODULE_EXPORT void
 psy_window_remove_stimulus(PsyWindow* window, PsyVisualStimulus* stimulus);
 
+G_MODULE_EXPORT PsyProgram*
+psy_window_get_shader_program(PsyWindow* window, PsyProgramType type);
 
 G_END_DECLS
 


### PR DESCRIPTION
Enables an example of OpenGL dynamic drawing of stimuli. The PsyGtkWindow is now able to draw circles, although the provided example is stretched to an ellipse, because of we don't transform space.