### PR TITLE
Feature/transformations

### DIFF
--- a/psy/backend_gtk/psy-gtk-window.c
+++ b/psy/backend_gtk/psy-gtk-window.c
@@ -304,10 +304,6 @@ get_artist_for_stimulus(PsyWindow* window, PsyVisualStimulus* stimulus, GType ty
 static void
 schedule_stimulus(PsyWindow* self, PsyVisualStimulus* stimulus)
 {
-    g_print("Scheduling stimulus %p on window %p\ns",
-            (void*) stimulus,
-            (gpointer) self);
-
     PsyGtkWindow* win = PSY_GTK_WINDOW(self);
 
     PsyArtist* artist = get_artist_for_stimulus( 

--- a/psy/backend_gtk/psy-gtk-window.c
+++ b/psy/backend_gtk/psy-gtk-window.c
@@ -70,15 +70,16 @@ static void
 on_canvas_resize(GtkDrawingArea* darea, gint width, gint height, gpointer data)
 {
     PsyGtkWindow *self = data;
-    (void) self;
     gtk_gl_area_make_current(GTK_GL_AREA(darea));
+
+    g_signal_emit_by_name(self, "resize", width, height); // allow clients to update
+
     glViewport(
             0,
             0,
             width > 0 ? (GLsizei) width : 0,
             height > 0 ? (GLsizei) height : 0
             );
-    g_print("width %d, height %d, data %p\n", width, height, data);
 }
 
 static void
@@ -161,9 +162,12 @@ on_canvas_unrealize(GtkGLArea* area, PsyGtkWindow* self)
 static void
 psy_gtk_window_init(PsyGtkWindow* self)
 {
+    // Setup a window with a OpenGL canvas as child.
     self->window = gtk_window_new();
     GtkWidget* canvas = gtk_gl_area_new();
     gtk_window_set_child(GTK_WINDOW(self->window), canvas);
+
+    // Create a table to find artist to draw the scene
     self->artists = g_hash_table_new_full(
             g_direct_hash,
             g_direct_equal,
@@ -247,7 +251,7 @@ set_monitor(PsyWindow* self, gint nth_monitor) {
 
     width_mm = gdk_monitor_get_width_mm(monitor);
     height_mm= gdk_monitor_get_height_mm(monitor);
-    gdouble mHz = gdk_monitor_get_refresh_rate(monitor);
+    gdouble mHz = gdk_monitor_get_refresh_rate(monitor); // milli Hertz
     gdouble Hz = mHz / 1000;
     PsyDuration* frame_duration = psy_duration_new(1/Hz);
 
@@ -338,7 +342,7 @@ remove_stimulus(PsyWindow* self, PsyVisualStimulus* stimulus)
             );
 }
 
-PsyProgram*
+static PsyProgram*
 get_shader_program(PsyWindow* self, PsyProgramType type)
 {
     PsyGtkWindow* win = PSY_GTK_WINDOW(self);
@@ -351,6 +355,56 @@ get_shader_program(PsyWindow* self, PsyProgramType type)
         default:
             g_critical("PsyGtkWindow doens't have a program for type %d", type);
             return NULL;
+    }
+}
+
+static void
+upload_projection_matrices(PsyWindow* self)
+{
+    PsyGtkWindow* win = PSY_GTK_WINDOW(self);
+    PsyMatrix4* projection = psy_window_get_projection(self);
+    GError* error = NULL;
+
+    if (win->picture_program) {
+        psy_program_use(win->picture_program, &error);
+        if (error) {
+            g_critical("Unable to set picture projection matrix: %s",
+                    error->message
+                    );
+            error = NULL;
+        }
+        psy_program_set_uniform_matrix4(
+                win->picture_program,
+                "projection",
+                projection,
+                &error
+                );
+        if (error) {
+            g_critical("Unable to set picture projection matrix: %s",
+                    error->message
+                    );
+            error = NULL;
+        }
+    }
+    if (win->uniform_color_program) {
+        psy_program_use(win->uniform_color_program, &error);
+        if (error) {
+            g_critical("Unable to set picture projection matrix: %s",
+                    error->message
+                    );
+            error = NULL;
+        }
+        psy_program_set_uniform_matrix4(
+                win->uniform_color_program,
+                "projection",
+                projection,
+                &error
+                );
+        if (error) {
+            g_critical("Unable to set picture projection matrix: %s",
+                    error->message
+                    );
+        }
     }
 }
 
@@ -370,6 +424,8 @@ psy_gtk_window_class_init(PsyGtkWindowClass* klass)
     psy_window_class->schedule_stimulus = schedule_stimulus;
     psy_window_class->remove_stimulus   = remove_stimulus;
     psy_window_class->get_shader_program= get_shader_program;
+
+    psy_window_class->upload_projection_matrices = upload_projection_matrices;
 }
 
 /**

--- a/psy/gl/psy-gl-circle.c
+++ b/psy/gl/psy-gl-circle.c
@@ -81,8 +81,6 @@ psy_gl_circle_finalize(GObject* object)
 static void
 gl_circle_draw(PsyArtist* self)
 {
-    //TODO activate a OpenGL program.
-
     PsyGlCircle* artist = PSY_GL_CIRCLE(self);
     PsyCircle* circle = PSY_CIRCLE(psy_artist_get_stimulus(self));
     PsyWindow* window = psy_artist_get_window(self);

--- a/psy/gl/psy-gl-circle.c
+++ b/psy/gl/psy-gl-circle.c
@@ -1,10 +1,13 @@
 
 #include <math.h>
 #include <epoxy/gl.h>
+#include <graphene.h>
 
+#include "graphene-matrix.h"
 #include "psy-circle.h"
 #include "psy-gl-circle.h"
 #include "psy-gl-vbuffer.h"
+#include "psy-matrix4.h"
 #include "psy-program.h"
 #include "psy-vbuffer.h"
 #include "psy-window.h"
@@ -82,16 +85,14 @@ gl_circle_draw(PsyArtist* self)
 
     PsyGlCircle* artist = PSY_GL_CIRCLE(self);
     PsyCircle* circle = PSY_CIRCLE(psy_artist_get_stimulus(self));
-    PsyWindow* window = psy_artist_get_window(artist);
+    PsyWindow* window = psy_artist_get_window(self);
+    GError* error = NULL;
+
     PsyProgram* program = psy_window_get_shader_program(
             window,
             PSY_PROGRAM_UNIFORM_COLOR
             );
 
-    gboolean store_vertices = FALSE;
-    gfloat radius;
-    GError* error = NULL;
-    
     psy_program_use(program, &error);
     if (error) {
         g_critical("PsyCircle unable to use program: %s", error->message);
@@ -99,6 +100,9 @@ gl_circle_draw(PsyArtist* self)
         error = NULL;
     }
 
+    gboolean store_vertices = FALSE;
+    gfloat radius;
+    
     guint num_vertices = psy_circle_get_num_vertices(circle);
     if (num_vertices != psy_vbuffer_get_nvertices(artist->vertices)) {
         psy_vbuffer_set_nvertices(artist->vertices, num_vertices);

--- a/psy/gl/psy-gl-program.c
+++ b/psy/gl/psy-gl-program.c
@@ -8,6 +8,7 @@
 #include "psy-gl-fragment-shader.h"
 
 #include <epoxy/gl.h>
+#include <epoxy/gl_generated.h>
 
 typedef struct _PsyGlProgram {
     PsyProgram           parent;
@@ -317,6 +318,25 @@ psy_gl_program_use_program(PsyProgram* self, GError **error)
 }
 
 static void
+psy_gl_program_set_uniform_matrix_4(
+        PsyProgram     *self,
+        const gchar    *name,
+        PsyMatrix4     *matrix,
+        GError        **error
+        )
+{
+    PsyGlProgram* program = PSY_GL_PROGRAM(self);
+    GLfloat elements[16];
+    psy_matrix4_get_elements(matrix, elements);
+
+    GLint location = glGetUniformLocation(program->object_id, name);
+    if (psy_gl_check_error(error))
+        return;
+
+    glUniformMatrix4fv(location, 1, GL_FALSE, elements);
+}
+
+static void
 psy_gl_program_class_init(PsyGlProgramClass* class)
 {
     GObjectClass       *gobject_class = G_OBJECT_CLASS(class);
@@ -349,6 +369,8 @@ psy_gl_program_class_init(PsyGlProgramClass* class)
     program_class->is_linked    = psy_gl_program_is_linked;
     program_class->use_program  = psy_gl_program_use_program;
 
+    program_class->set_uniform_matrix4 = psy_gl_program_set_uniform_matrix_4;
+
     gl_program_properties[PROP_OBJECT_ID] = g_param_spec_string(
             "object-id",
             "Object ID",
@@ -360,7 +382,7 @@ psy_gl_program_class_init(PsyGlProgramClass* class)
     gl_program_properties[PROP_IS_LINKED] = g_param_spec_boolean(
             "is-linked",
             "Is linked",
-            "Whether the shader program is succesfully linked.",
+            "Whether the shader program is successfully linked.",
             FALSE,
             G_PARAM_READABLE
             );

--- a/psy/psy-matrix4.cpp
+++ b/psy/psy-matrix4.cpp
@@ -454,3 +454,14 @@ psy_matrix4_ptr(PsyMatrix4* self)
 
     return glm::value_ptr(*self->matrix);
 }
+
+void
+psy_matrix4_get_elements(PsyMatrix4* self, gfloat* elements)
+{
+    g_return_if_fail(PSY_IS_MATRIX4(self));
+    float* out = &elements[0];
+    gdouble* in = glm::value_ptr(*(self->matrix)); 
+    for (; out < &elements[16]; in++, out++)
+        *out = (gfloat) *in;
+}
+

--- a/psy/psy-matrix4.h
+++ b/psy/psy-matrix4.h
@@ -3,6 +3,7 @@
 #define PSY_MATRIX4_H
 
 #include <glib-object.h>
+#include <gio/gio.h>
 
 G_BEGIN_DECLS
 
@@ -50,6 +51,9 @@ gboolean psy_matrix4_equals(PsyMatrix4* v1, PsyMatrix4* v2);
 gboolean psy_matrix4_not_equals(PsyMatrix4* v1, PsyMatrix4* v2);
 
 const gdouble* psy_matrix4_ptr(PsyMatrix4* self);
+
+G_MODULE_EXPORT void
+psy_matrix4_get_elements(PsyMatrix4*, gfloat* elements);
 
 
 G_END_DECLS

--- a/psy/psy-program.c
+++ b/psy/psy-program.c
@@ -1,6 +1,7 @@
 
 
 #include "psy-program.h"
+#include "psy-matrix4.h"
 #include "psy-shader.h"
 
 typedef struct _PsyProgramPrivate {
@@ -258,4 +259,25 @@ psy_program_use(PsyProgram* self, GError **error)
 
     klass->use_program(self, error);
 }
+
+void
+psy_program_set_uniform_matrix4(
+        PsyProgram     *self,
+        const gchar    *name,
+        PsyMatrix4     *matrix,
+        GError        **error
+        )
+{
+    g_return_if_fail(PSY_IS_PROGRAM(self));
+    g_return_if_fail(name);
+    g_return_if_fail(PSY_IS_MATRIX4(matrix));
+    g_return_if_fail(error == NULL || *error == NULL);
+
+    PsyProgramClass* class = PSY_PROGRAM_GET_CLASS(self);
+
+    g_return_if_fail(class->set_uniform_matrix4);
+
+    class->set_uniform_matrix4(self, name, matrix, error);
+}
+
 

--- a/psy/psy-program.h
+++ b/psy/psy-program.h
@@ -1,6 +1,7 @@
 #ifndef PSY_PROGRAM_H
 #define PSY_PROGRAM_H
 
+#include "psy-matrix4.h"
 #include "psy-shader.h"
 #include <gio/gio.h>
 
@@ -67,6 +68,12 @@ typedef struct _PsyProgramClass {
 
     void (*use_program) (PsyProgram* program, GError ** error);
 
+    void (*set_uniform_matrix4) (PsyProgram     *program,
+                                 const gchar    *name,
+                                 PsyMatrix4     *matrix,
+                                 GError        **error
+                                 );
+
 } PsyProgramClass;
 
 
@@ -109,6 +116,7 @@ psy_program_set_fragment_shader_from_path(PsyProgram    *program,
                                           const gchar   *shader_path,
                                           GError       **error);
 
+
 G_MODULE_EXPORT void
 psy_program_link(PsyProgram *self, GError **error);
 
@@ -117,6 +125,14 @@ psy_program_is_linked(PsyProgram *self);
 
 G_MODULE_EXPORT void
 psy_program_use(PsyProgram* self, GError **error);
+
+G_MODULE_EXPORT void
+psy_program_set_uniform_matrix4(
+        PsyProgram     *program,
+        const gchar    *name,
+        PsyMatrix4     *matrix,
+        GError        **error
+        );
 
 G_END_DECLS
 

--- a/psy/psy-window.c
+++ b/psy/psy-window.c
@@ -234,7 +234,6 @@ set_monitor(PsyWindow* self, gint nth_monitor) {
 static void resize(PsyWindow* self, gint width, gint height)
 {
     PsyWindowPrivate* priv = psy_window_get_instance_private(self);
-    g_print ("Resizing window to %d, %d\n", width, height);
     priv->width = width;
     priv->height = height;
 

--- a/psy/psy-window.c
+++ b/psy/psy-window.c
@@ -29,16 +29,22 @@
 #include "psy-time-point.h"
 #include "psy-visual-stimulus.h"
 #include "psy-window.h"
+#include "psy-matrix4.h"
+#include "enum-types.h"
 
 typedef struct PsyWindowPrivate {
     gint            monitor;
     guint           n_frames;
+    gint            width, height;
     gint            width_mm, height_mm;
     gfloat          back_ground_color[4];
 
     GHashTable*     stimuli;
     GTree*          sorted_stimuli;
     PsyDuration*    frame_dur;
+
+    gint            projection_style;
+    PsyMatrix4*     projection_matrix;
 } PsyWindowPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(PsyWindow, psy_window, G_TYPE_OBJECT)
@@ -46,18 +52,21 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(PsyWindow, psy_window, G_TYPE_OBJECT)
 typedef enum {
     CLEAR,
     DRAW_STIMULI,
+    RESIZE,
     LAST_SIGNAL,
 } PsyWindowSignal;
 
 typedef enum {
     N_MONITOR = 1,
     BACKGROUND_COLOR_VALUES,
+    WIDTH,
+    HEIGHT,
     WIDTH_MM,
     HEIGHT_MM,
     FRAME_DUR,
+    PROJECTION_STYLE,
     N_PROPS
 } PsyWindowProperty;
-
 
 static void
 psy_window_set_property(GObject        *object,
@@ -82,6 +91,9 @@ psy_window_set_property(GObject        *object,
         case HEIGHT_MM:
             psy_window_set_height_mm(self, g_value_get_int(value));
             break;
+        case PROJECTION_STYLE:
+            psy_window_set_projection_style(self, g_value_get_int(value));
+            break;
         case FRAME_DUR:
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, spec);
@@ -100,6 +112,12 @@ psy_window_get_property(GObject        *object,
         case N_MONITOR:
             g_value_set_int(value, psy_window_get_monitor(self));
             break;
+        case WIDTH:
+            g_value_set_int(value, psy_window_get_width(self));
+            break;
+        case HEIGHT:
+            g_value_set_int(value, psy_window_get_height(self));
+            break;
         case WIDTH_MM:
             g_value_set_int(value, psy_window_get_width_mm(self));
             break;
@@ -108,6 +126,9 @@ psy_window_get_property(GObject        *object,
             break;
         case FRAME_DUR:
             g_value_set_object(value, psy_window_get_frame_dur(self));
+            break;
+        case PROJECTION_STYLE:
+            g_value_set_int(value, psy_window_get_projection_style(self));
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, spec);
@@ -196,7 +217,7 @@ psy_window_finalize(GObject* gobject)
 }
 
 static GParamSpec* obj_properties[N_PROPS];
-//static guint window_signals[LAST_SIGNAL];
+static guint window_signals[LAST_SIGNAL];
 
 static gint
 get_monitor(PsyWindow* self) {
@@ -210,6 +231,30 @@ set_monitor(PsyWindow* self, gint nth_monitor) {
     priv->monitor = nth_monitor;
 }
 
+static void resize(PsyWindow* self, gint width, gint height)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    g_print ("Resizing window to %d, %d\n", width, height);
+    priv->width = width;
+    priv->height = height;
+
+    PsyWindowClass* klass = PSY_WINDOW_GET_CLASS(self);
+    klass->set_projection_matrix(self, klass->create_projection_matrix(self));
+}
+
+static void
+set_width(PsyWindow* self, gint width) {
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    priv->width = width;
+}
+
+static void
+set_height(PsyWindow* self, gint height) {
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    priv->width = height;
+}
+
+
 static void
 set_frame_dur(PsyWindow* self, PsyDuration* dur)
 {
@@ -219,7 +264,6 @@ set_frame_dur(PsyWindow* self, PsyDuration* dur)
 
 static void
 schedule_stimulus(PsyWindow* self, PsyVisualStimulus* stimulus) {
-    g_print("%s\n", __PRETTY_FUNCTION__ );
     PsyWindowPrivate* priv = psy_window_get_instance_private(self);
 
     // Check if the stimulus is already scheduled
@@ -241,6 +285,9 @@ static void
 draw(PsyWindow* self, guint64 frame_num, PsyTimePoint* tp)
 {
     PsyWindowClass* cls = PSY_WINDOW_GET_CLASS(self);
+
+    // upload the default projection matrices.
+    cls->upload_projection_matrices(self);
     g_return_if_fail(cls->clear);
     g_return_if_fail(cls->draw_stimuli);
 
@@ -312,6 +359,92 @@ set_monitor_size_mm(PsyWindow* self, gint width_mm, gint height_mm)
     priv->height_mm = height_mm;
 }
 
+PsyMatrix4*
+create_projection_matrix(PsyWindow* self) {
+    //TODO check whether near and far are valid.
+    gint w, h;
+    gfloat width, height, width_mm, height_mm;
+    gint w_mm, h_mm;
+    gfloat left = 0.0, right = 0.0, bottom, top, near = 100.0, far = -100.0;
+
+    g_object_get(self,
+            "width", &w,
+            "height", &h,
+            "width_mm", &w_mm,
+            "height_mm", &h_mm,
+            NULL);
+    width = (gfloat)w;
+    height= (gfloat)h;
+    width_mm = (gfloat) w_mm;
+    height_mm = (gfloat) h_mm;
+    bottom = height;
+    top = 0.0;
+
+    gint style = psy_window_get_projection_style(self);
+
+    if (style & PSY_WINDOW_PROJECTION_STYLE_CENTER) {
+        if (style & PSY_WINDOW_PROJECTION_STYLE_PIXELS) {
+            left   =   -width / 2;
+            right  =    width / 2;
+            top    =   height / 2;
+            bottom =  -height / 2;
+        }
+        else if (style & PSY_WINDOW_PROJECTION_STYLE_METER) {
+            left   =   -(width_mm / 1000) / 2;
+            right  =    (width_mm / 1000) / 2;
+            top    =   (height_mm / 1000) / 2;
+            bottom =  -(height_mm / 1000) / 2;
+        }
+        else if (style & PSY_WINDOW_PROJECTION_STYLE_MILLIMETER) {
+            left   =   -width_mm / 2;
+            right  =    width_mm / 2;
+            top    =   height_mm / 2;
+            bottom =  -height_mm / 2;
+        }
+        else {
+            g_assert(style & PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES);
+            g_warning("visual degrees are yet unsupported");
+            return NULL;
+        }
+    }
+    else {
+        g_assert(style & PSY_WINDOW_PROJECTION_STYLE_C);
+        if (style & PSY_WINDOW_PROJECTION_STYLE_PIXELS) {
+            left   =  0.0;
+            right  =  width;
+            top    =  0.0;
+            bottom =  height;
+        }
+        else if (style & PSY_WINDOW_PROJECTION_STYLE_METER) {
+            left   =  0.0;
+            right  =  width_mm / 1000;
+            top    =  0.0;
+            bottom =  height_mm / 1000;
+        }
+        else if (style & PSY_WINDOW_PROJECTION_STYLE_MILLIMETER) {
+            left   =  0.0;
+            right  =  width_mm;
+            top    =  0.0;
+            bottom =  height_mm;
+        }
+        else {
+            g_assert(style & PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES);
+            g_warning("visual degrees are yet unsupported");
+            return NULL;
+        }
+    }
+
+    return psy_matrix4_new_ortographic(left, right, bottom, top, near, far);
+}
+
+static void
+set_projection_matrix(PsyWindow* self, PsyMatrix4* projection)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    g_clear_object(&priv->projection_matrix);
+    priv->projection_matrix = projection;
+}
+
 static void
 psy_window_class_init(PsyWindowClass* klass)
 {
@@ -325,6 +458,11 @@ psy_window_class_init(PsyWindowClass* klass)
     klass->get_monitor          = get_monitor;
     klass->set_monitor          = set_monitor;
 
+    klass->resize               = resize;
+
+    klass->set_width            = set_width;
+    klass->set_height           = set_height;
+
     klass->draw                 = draw;
     klass->draw_stimuli         = draw_stimuli;
     klass->set_monitor_size_mm  = set_monitor_size_mm;
@@ -333,6 +471,9 @@ psy_window_class_init(PsyWindowClass* klass)
 
     klass->schedule_stimulus    = schedule_stimulus;
     klass->remove_stimulus      = remove_stimulus;
+
+    klass->create_projection_matrix = create_projection_matrix;
+    klass->set_projection_matrix = set_projection_matrix;
 
     /**
      * PsyWindow:n-monitor:
@@ -348,6 +489,31 @@ psy_window_class_init(PsyWindowClass* klass)
                          G_MAXINT32,
                          0,
                          G_PARAM_CONSTRUCT | G_PARAM_READWRITE
+                         );
+    /**
+     * PsyWindow:width:
+     */
+    obj_properties[WIDTH] =
+        g_param_spec_int("width",
+                         "Width",
+                         "The width of the window in pixels",
+                         0,
+                         G_MAXINT32,
+                         0,
+                         G_PARAM_READABLE
+                         );
+    
+    /**
+     * PsyWindow:height:
+     */
+    obj_properties[HEIGHT] =
+        g_param_spec_int("height",
+                         "",
+                         "The height of the window in pixel.",
+                         0,
+                         G_MAXINT32,
+                         0,
+                         G_PARAM_READABLE
                          );
 
     /**
@@ -420,7 +586,57 @@ psy_window_class_init(PsyWindowClass* klass)
             G_PARAM_READABLE
             );
 
+    /**
+     * PsyWindow:projection-style:
+     *
+     * The manner in which geometrical units normalized coordinates are
+     * projected to the physical output parameters. In OpenGL for example
+     * units are specified normalized device parameters between -1.0 and 1.0
+     * This is for other users perhaps not as convenient. For our 2D drawing
+     * it might be more appropriate to specify the range in pixels.
+     * This is a combination `PsyWindowProjectionStyle` flags
+     * When setting the property one should specify exactly one of:
+     *
+     *  - PSY_WINDOW_PROJECTION_STYLE_C
+     *  - PSY_WINDOW_PROJECTION_STYLE_CENTER
+     *
+     * and exactly one of:
+     *
+     *  - PSY_WINDOW_PROJECTION_STYLE_PIXELS
+     *  - PSY_WINDOW_PROJECTION_STYLE_METER
+     *  - PSY_WINDOW_PROJECTION_STYLE_MILLIMETER
+     *  - PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES
+     *
+     * if you would fail to this no valid projection can be set and probably
+     * the last one will be kept.
+     * The default is:
+     *  PSY_WINDOW_PROJECTION_STYLE_CENTER | PSY_WINDOW_PROJECTION_STYLE_PIXELS
+     */
+    obj_properties[PROJECTION_STYLE] = g_param_spec_int(
+            "projection-style",
+            "Projection style",
+            "Tells what the projection matrix is doing for you",
+            0,
+            G_MAXINT32,
+            PSY_WINDOW_PROJECTION_STYLE_CENTER | PSY_WINDOW_PROJECTION_STYLE_PIXELS,
+            G_PARAM_READWRITE | G_PARAM_CONSTRUCT
+            );
+
     g_object_class_install_properties(object_class, N_PROPS, obj_properties);
+
+    window_signals[RESIZE] = g_signal_new(
+            "resize",
+            PSY_TYPE_WINDOW,
+            G_SIGNAL_RUN_LAST,
+            G_STRUCT_OFFSET(PsyWindowClass, resize),
+            NULL,
+            NULL,
+            NULL,
+            G_TYPE_NONE,
+            2,
+            G_TYPE_INT,
+            G_TYPE_INT
+            );
 
 //    /**
 //     * PsyWindow::clear
@@ -548,6 +764,36 @@ psy_window_get_background_color_values(PsyWindow* self, gfloat* color)
     memcpy(color,
            priv->back_ground_color,
            sizeof(priv->back_ground_color));
+}
+
+/**
+ * psy_window_get_width:
+ * @self:A #PsyWindow instance
+ *
+ * Returns: the width in pixels of the window
+ */
+gint
+psy_window_get_width(PsyWindow* self)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);;
+    g_return_val_if_fail(PSY_IS_WINDOW(self), -1);
+    
+    return priv->width;
+}
+
+/**
+ * psy_window_get_height:
+ * @self:A #PsyWindow instance
+ *
+ * Returns: the height in pixels of the window
+ */
+gint
+psy_window_get_height(PsyWindow* self)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    g_return_val_if_fail(PSY_IS_WINDOW(self), -1);
+    
+    return priv->height;
 }
 
 /**
@@ -697,5 +943,96 @@ psy_window_get_shader_program(PsyWindow* self, PsyProgramType type)
     g_return_val_if_fail(klass->get_shader_program, NULL);
 
     return klass->get_shader_program(self, type);
+}
+
+/**
+ * psy_window_set_projection_style:
+ * @window: an instance of `PsyWindow`
+ * @style: an instance of `PsyWindowProjectionStyle` an | orable combination
+ *         of `PsyWindowProjectionStyle` Take note some flags may not be
+ *         orred together and at least some must be set.
+ *                      
+ *
+ * Set the style of projection of the window see `PsyWindow:projection-style`
+ */
+void
+psy_window_set_projection_style(PsyWindow* self, gint style)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    PsyWindowClass* klass = PSY_WINDOW_GET_CLASS(self);
+
+    gint origin_style = 0;
+    gint unit_style = 0;
+
+    g_return_if_fail(PSY_IS_WINDOW(self));
+    
+    if (style & PSY_WINDOW_PROJECTION_STYLE_C)
+        origin_style++;
+    if (style & PSY_WINDOW_PROJECTION_STYLE_CENTER)
+        origin_style++;
+
+    if (origin_style != 1) {
+        g_critical("%s:You should set PSY_WINDOW_PROJECTION_STYLE_C or "
+                   "PSY_WINDOW_PROJECTION_STYLE_CENTER", __func__);
+        return;
+    }
+
+    if (style & PSY_WINDOW_PROJECTION_STYLE_PIXELS)
+        unit_style++;
+    if (style & PSY_WINDOW_PROJECTION_STYLE_METER)
+        unit_style++;
+    if (style & PSY_WINDOW_PROJECTION_STYLE_MILLIMETER)
+        unit_style++;
+    if (style & PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES) {
+        g_warning("Oops setting visual degrees is currently not supported.");
+        unit_style++;
+    }
+
+    if (unit_style != 1) {
+        g_critical("%s: You should set PSY_WINDOW_PROJECTION_STYLE_PIXELS or "
+                "PSY_WINDOW_PROJECTION_STYLE_METER or"
+                "PSY_WINDOW_PROJECTION_STYLE_MILLIMETER or"
+                "PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES",
+                __func__
+                );
+        return;
+    }
+
+    priv->projection_style = style;
+
+    PsyMatrix4* projection = klass->create_projection_matrix(self);
+
+    g_clear_object(&priv->projection_matrix);
+    priv->projection_matrix = projection;
+}
+
+/**
+ * psy_window_get_projection_style:
+ * @window: an instance of `PsyWindow`
+ *
+ * Returns: the style of projection of the window see `PsyWindow:projection-style`
+ */
+gint
+psy_window_get_projection_style(PsyWindow* self)
+{
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+    
+    g_return_val_if_fail(PSY_IS_WINDOW(self), 0);
+
+    return priv->projection_style;
+}
+
+/**
+ * psy_window_get_projection:
+ * @window: an instance of `PsyWindow`
+ *
+ * Returns: the projection matrix used by this window
+ */
+PsyMatrix4*
+psy_window_get_projection(PsyWindow* self) {
+    PsyWindowPrivate* priv = psy_window_get_instance_private(self);
+
+    g_return_val_if_fail(PSY_IS_WINDOW(self), NULL);
+    return priv->projection_matrix;
 }
 

--- a/psy/psy-window.h
+++ b/psy/psy-window.h
@@ -13,6 +13,59 @@ G_BEGIN_DECLS
 struct _PsyVisualStimulus;
 typedef struct _PsyVisualStimulus PsyVisualStimulus;
 
+/**
+ * PsyWindowProjectionStyle:
+ * @PSY_WINDOW_PROJECTION_STYLE_C: 0.0, 0.0 is in the upper left corner of the
+ *                                 window. With positive y coordinates going down.
+ * @PSY_WINDOW_PROJECTION_STYLE_CENTER: 0.0, 0.0 is in the center of the window
+ *                            with positive y coordinates is going up.
+ * @PSY_WINDOW_PROJECTION_STYLE_PIXELS: Create a projection matrix that makes the
+ *                            screen as wide,tall as the dimensions of the
+ *                            number of pixels. Stimuli may than also be
+ *                            specified in pixels.
+ * @PSY_WINDOW_PROJECTION_STYLE_METER:  Create a projection matrix based on the number
+ *                            meters the window is, the sizes of stimuli can be
+ *                            specified in meters.
+ * @PSY_WINDOW_PROJECTION_STYLE_MILLIMETER: Create a projection matrix based on the
+ *                            number meters the window is tall. Stimuli
+ *                            may also be presented in millimeters.
+ * @PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES: Create a projection matrix based on 
+ *                            the number of visual degrees the window is tall.
+ *                            Stimuli should be specified in visual degrees.
+ *                            NOT IMPLEMENTED YET.
+ *
+ * Instances of `PsyWindow` use an orthographic projection by default. We
+ * focus on 2 Dimensional stimuli. This enum can be used to set the 
+ * projection-style property of a PsyWindow. By default the projection is
+ * set up with the point[0.0, 0.0] in the center of the screen, regardless
+ * of the units used.
+ *
+ * The PsyWindow is able to tell the size in meters of the window when it's
+ * fullscreen and also the "size" in pixels. It doesn't know how far the
+ * subject is sitting from the screen, so this need to be specified when using
+ * #PsyProjectionStyleVisualDegrees.
+ *
+ * When using these flags one should always specify exactly one of:
+ *
+ *  - PSY_WINDOW_PROJECTION_STYLE_C
+ *  - PSY_WINDOW_PROJECTION_STYLE_CENTER
+ *
+ * and exactly one of 
+ *
+ *  - PSY_WINDOW_PROJECTION_STYLE_PIXELS
+ *  - PSY_WINDOW_PROJECTION_STYLE_METER
+ *  - PSY_WINDOW_PROJECTION_STYLE_MILLIMETER
+ *  - PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES
+ */
+typedef enum _PsyWindowProjectionStyle {
+    PSY_WINDOW_PROJECTION_STYLE_C               = 1 << 0,
+    PSY_WINDOW_PROJECTION_STYLE_CENTER          = 1 << 1,
+    PSY_WINDOW_PROJECTION_STYLE_PIXELS          = 1 << 2,
+    PSY_WINDOW_PROJECTION_STYLE_METER           = 1 << 3,
+    PSY_WINDOW_PROJECTION_STYLE_MILLIMETER      = 1 << 4,
+    PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES  = 1 << 5
+} PsyWindowProjectionStyle;
+
 #define PSY_TYPE_WINDOW psy_window_get_type()
 G_DECLARE_DERIVABLE_TYPE(PsyWindow, psy_window, PSY, WINDOW, GObject)
 
@@ -21,6 +74,8 @@ G_DECLARE_DERIVABLE_TYPE(PsyWindow, psy_window, PSY, WINDOW, GObject)
  * @parent_class: The parent class
  * @set_monitor: Set the window at monitor x.
  * @get_monitor: Retrieve the number of the monitor
+ * @get_width: Get the window width in pixels
+ * @get_height: Get the window height in pixels
  * @draw: clears the window, than draws the stimuli.
  * @clear: A function to clear the picture to the background color
  * @draw_stimuli: A function that draws the stimuli.
@@ -31,6 +86,8 @@ G_DECLARE_DERIVABLE_TYPE(PsyWindow, psy_window, PSY, WINDOW, GObject)
  * @get_frame_dur:get the duration of the frame
  * @schedule_stimulus:This function is called when a new stimulus is scheduled
  *                    for this window.
+ * @create_projection_matrix: create an projection matrix that is suitable
+ *                            for the current value of 
  */
 typedef struct _PsyWindowClass {
     GObjectClass parent_class;
@@ -38,7 +95,12 @@ typedef struct _PsyWindowClass {
     /*< public >*/
 
     void (*set_monitor)(PsyWindow* self, gint nth_monitor);
-    int  (*get_monitor)(PsyWindow* self);
+    gint (*get_monitor)(PsyWindow* self);
+
+    void (*resize) (PsyWindow* self, gint width, gint height);
+
+    void (*set_width)(PsyWindow* window, gint width);
+    void (*set_height)(PsyWindow* window, gint width);
 
     void (*draw) (PsyWindow* self, guint64 frame_num, PsyTimePoint* frame_time);
     void (*clear)(PsyWindow* self);
@@ -56,6 +118,10 @@ typedef struct _PsyWindowClass {
     void (*remove_stimulus) (PsyWindow* self, PsyVisualStimulus* stimulus);
 
     PsyProgram* (*get_shader_program)(PsyWindow* window, PsyProgramType type);
+
+    PsyMatrix4* (*create_projection_matrix)(PsyWindow* self);
+    void (*set_projection_matrix)(PsyWindow* self, PsyMatrix4* projection);
+    void (*upload_projection_matrices)(PsyWindow* window);
     
     /*< private >*/
 
@@ -84,6 +150,12 @@ psy_window_get_width_mm(PsyWindow* window);
 G_MODULE_EXPORT gint 
 psy_window_get_height_mm(PsyWindow* window);
 
+G_MODULE_EXPORT gint
+psy_window_get_width(PsyWindow* window);
+
+G_MODULE_EXPORT gint
+psy_window_get_height(PsyWindow* window);
+
 G_MODULE_EXPORT void
 psy_window_set_width_mm(PsyWindow* window, gint width_mm);
 
@@ -101,6 +173,16 @@ psy_window_remove_stimulus(PsyWindow* window, PsyVisualStimulus* stimulus);
 
 G_MODULE_EXPORT PsyProgram*
 psy_window_get_shader_program(PsyWindow* window, PsyProgramType type);
+
+G_MODULE_EXPORT void
+psy_window_set_projection_style(PsyWindow* window, gint projection_style);
+
+G_MODULE_EXPORT gint
+psy_window_get_projection_style(PsyWindow* window);
+
+G_MODULE_EXPORT PsyMatrix4*
+psy_window_get_projection(PsyWindow* window);
+
 
 G_END_DECLS
 

--- a/psy/uniform-color.vert
+++ b/psy/uniform-color.vert
@@ -1,8 +1,13 @@
 #version 330 core
+
 layout (location = 0) in vec3 aPos; // the position variable has attribute position 0
+
+uniform mat4 projection;
+//uniform mat4 model;
   
 void main()
 {
     // see how we directly give a vec3 to vec4's constructor
-    gl_Position = vec4(aPos, 1.0);
+    vec4 vertex = vec4(aPos, 1.0); 
+    gl_Position = projection * vertex;
 }

--- a/psy/v-shader.vert
+++ b/psy/v-shader.vert
@@ -1,7 +1,12 @@
 #version 330 core
 layout (location = 0) in vec3 aPos; // the position variable has attribute position 0
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
   
 out vec4 vertexColor; // specify a color output to the fragment shader
+
 
 void main()
 {


### PR DESCRIPTION
This feature add some default projection transformations. Previously when a Circle was specified is was drawn in Normalized Device coordinates. This means that all coordinates within a screen were inside the box with x-, y- and z-coordinates of [-1, 1], if a coordinate would fall outside of this box It wouldn't be drawn.
This feature adds a window-projection-style property to the window. This allows for specifying the style used for the projection.
This allows for encoding the:
- ***units*** of the projection eg. pixels or millimeters or meters (or visual degrees, however this is not implemented yet).
- ***style***
  -  center, the origin (0, 0) is at the center and positive y is going up
  - C, the origin is at the upper left corner of your screen and positive y coordinates are going down