### PR TITLE
Feature/visualbase updates

### DIFF
--- a/psy/psy-circle.c
+++ b/psy/psy-circle.c
@@ -130,7 +130,7 @@ psy_circle_new(PsyWindow* window)
 
 /**
  * psy_circle:(method)
- * @circle: an instance of %PsyCircle
+ * @circle: an instance of `PsyCircle`
  *
  * Returns: a new instance of `PsyCircle` with the provided values.
  */
@@ -142,8 +142,8 @@ psy_circle_new_full(
     return g_object_new(
             PSY_TYPE_CIRCLE,
             "window", window,
-//            "x", x,
-//            "y", y,
+            "x", x,
+            "y", y,
             "radius", radius,
             "num_vertices", num_vertices,
             NULL);

--- a/psy/psy-circle.c
+++ b/psy/psy-circle.c
@@ -53,10 +53,10 @@ circle_get_property(GObject       *object,
 
     switch((CircleProperty) property_id) {
         case PROP_RADIUS:
-            g_value_set_int64(value, priv->radius);
+            g_value_set_float(value, priv->radius);
             break;
         case PROP_NUM_VERTICES:
-            g_value_set_int64(value, priv->num_vertices);
+            g_value_set_uint(value, priv->num_vertices);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -235,7 +235,7 @@ psy_visual_stimulus_class_init(PsyVisualStimulusClass* klass)
     visual_stimulus_properties[PROP_START_FRAME] = g_param_spec_int64(
             "start-frame",
             "StartFrame",
-            "The number of the frame on which this stimulus should be prensented",
+            "The number of the frame on which this stimulus should be presented",
             0, G_MAXINT64, 0,
             G_PARAM_READABLE
             );

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -1,5 +1,8 @@
 
+#include <math.h>
+
 #include "psy-visual-stimulus.h"
+#include "glibconfig.h"
 #include "psy-stimulus.h"
 #include "psy-window.h"
 
@@ -8,6 +11,7 @@ typedef struct PsyVisualStimulusPrivate {
      gint64     nth_frame;
      gint64     num_frames;
      gint64     start_frame;
+     gfloat     x, y, z;
 } PsyVisualStimulusPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(
@@ -20,6 +24,9 @@ typedef enum {
     PROP_NUM_FRAMES,    // The number of frames the stimulus will be presented
     PROP_NTH_FRAME,     // the frame for which we are rendering
     PROP_START_FRAME,   // the frame at which this object should be first presented
+    PROP_X,             // the x coordinate of the stimulus
+    PROP_Y,             // the y coordinate of the stimulus
+    PROP_Z,             // the z coordinate of the stimulus
     NUM_PROPERTIES
 } VisualStimulusProperty;
 
@@ -43,6 +50,15 @@ psy_visual_stimulus_set_property(GObject       *object,
     switch((VisualStimulusProperty) property_id) {
         case PROP_WINDOW:
             psy_visual_stimulus_set_window(self, g_value_get_object(value));
+            break;
+        case PROP_X:
+            psy_visual_stimulus_set_x(self, g_value_get_float(value));
+            break;
+        case PROP_Y:
+            psy_visual_stimulus_set_y(self, g_value_get_float(value));
+            break;
+        case PROP_Z:
+            psy_visual_stimulus_set_z(self, g_value_get_float(value));
             break;
         case PROP_NUM_FRAMES: // gettable only
         case PROP_NTH_FRAME:  // gettable only
@@ -74,6 +90,15 @@ psy_visual_stimulus_get_property(GObject       *object,
             break;
         case PROP_START_FRAME:
             g_value_set_int64(value, priv->start_frame);
+            break;
+        case PROP_X:
+            g_value_set_float(value, priv->x);
+            break;
+        case PROP_Y:
+            g_value_set_float(value, priv->y);
+            break;
+        case PROP_Z:
+            g_value_set_float(value, priv->z);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
@@ -213,6 +238,51 @@ psy_visual_stimulus_class_init(PsyVisualStimulusClass* klass)
             "The number of the frame on which this stimulus should be prensented",
             0, G_MAXINT64, 0,
             G_PARAM_READABLE
+            );
+
+    /**
+     * PsyVisualStimulus:x
+     *
+     * The x coordinate of the stimulus
+     */
+    visual_stimulus_properties[PROP_X] = g_param_spec_float(
+            "x",
+            "x-coordinate",
+            "the x coordinate of the stimulus",
+            -G_MAXFLOAT,
+            G_MAXFLOAT,
+            0,
+            G_PARAM_READWRITE
+            );
+    
+    /**
+     * PsyVisualStimulus:y
+     *
+     * The y coordinate of the stimulus
+     */
+    visual_stimulus_properties[PROP_Y] = g_param_spec_float(
+            "y",
+            "y-coordinate",
+            "the y coordinate of the stimulus",
+            -G_MAXFLOAT,
+            G_MAXFLOAT,
+            0,
+            G_PARAM_READWRITE
+            );
+    
+    /**
+     * PsyVisualStimulus:z
+     *
+     * The z coordinate of the stimulus
+     */
+    visual_stimulus_properties[PROP_Z] = g_param_spec_float(
+            "z",
+            "z-coordinate",
+            "the z coordinate of the stimulus",
+            -G_MAXFLOAT,
+            G_MAXFLOAT,
+            0,
+            G_PARAM_READWRITE
             );
     
     g_object_class_install_properties(
@@ -404,5 +474,104 @@ psy_visual_stimulus_get_start_frame(PsyVisualStimulus* self)
     g_return_val_if_fail(PSY_IS_VISUAL_STIMULUS(self), -1);
     
     return priv->start_frame;
+}
+
+/**
+ * psy_visual_stimulus_get_x:
+ * @self: an instance of `PsyVisualStimulus`
+ *
+ * Get the x coordinate of the stimulus.
+ *
+ * Returns: the x coordinate of the stimulus
+ */
+gfloat
+psy_visual_stimulus_get_x(PsyVisualStimulus* self)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_val_if_fail(PSY_IS_VISUAL_STIMULUS(self), NAN);
+
+    return priv->x;
+}
+
+/**
+ * psy_visual_stimulus_set_x:
+ * @self: an instance of `PsyVisualStimulus`
+ * @x: a `gfloat` representing the x coordinate.
+ *
+ * Set the new value for the x-coordinate
+ */
+void
+psy_visual_stimulus_set_x(PsyVisualStimulus* self, gfloat x)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_if_fail(PSY_IS_VISUAL_STIMULUS(self));
+
+    priv->x = x;
+}
+
+/**
+ * psy_visual_stimulus_get_y:
+ * @self: an instance of `PsyVisualStimulus`
+ *
+ * Get the y coordinate of the stimulus.
+ *
+ * Returns: the y coordinate of the stimulus
+ */
+gfloat
+psy_visual_stimulus_get_y(PsyVisualStimulus* self)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_val_if_fail(PSY_IS_VISUAL_STIMULUS(self), NAN);
+
+    return priv->y;
+}
+
+/**
+ * psy_visual_stimulus_set_y:
+ * @self: an instance of `PsyVisualStimulus`
+ * @y: a `gfloat` representing the y coordinate.
+ *
+ * Set the new value for the y-coordinate
+ */
+void
+psy_visual_stimulus_set_y(PsyVisualStimulus* self, gfloat y)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_if_fail(PSY_IS_VISUAL_STIMULUS(self));
+
+    priv->y = y;
+}
+
+/**
+ * psy_visual_stimulus_get_z:
+ * @self: an instance of `PsyVisualStimulus`
+ *
+ * Get the z coordinate of the stimulus.
+ *
+ * Returns: the z coordinate of the stimulus
+ */
+gfloat
+psy_visual_stimulus_get_z(PsyVisualStimulus* self)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_val_if_fail(PSY_IS_VISUAL_STIMULUS(self), NAN);
+
+    return priv->z;
+}
+
+/**
+ * psy_visual_stimulus_set_z:
+ * @self: an instance of `PsyVisualStimulus`
+ * @z: a `gfloat` representing the z coordinate.
+ *
+ * Set the new value for the z-coordinate
+ */
+void
+psy_visual_stimulus_set_z(PsyVisualStimulus* self, gfloat z)
+{
+    PsyVisualStimulusPrivate* priv = psy_visual_stimulus_get_instance_private(self);
+    g_return_if_fail(PSY_IS_VISUAL_STIMULUS(self));
+
+    priv->z = z;
 }
 

--- a/psy/psy-visual-stimulus.h
+++ b/psy/psy-visual-stimulus.h
@@ -51,4 +51,20 @@ psy_visual_stimulus_set_start_frame(
 G_MODULE_EXPORT gint64
 psy_visual_stimulus_get_start_frame(PsyVisualStimulus* stimulus);
 
+G_MODULE_EXPORT gfloat
+psy_visual_stimulus_get_x(PsyVisualStimulus* stimulus);
+G_MODULE_EXPORT void 
+psy_visual_stimulus_set_x(PsyVisualStimulus* stimulus, gfloat x);
+
+G_MODULE_EXPORT gfloat
+psy_visual_stimulus_get_y(PsyVisualStimulus* stimulus);
+G_MODULE_EXPORT void 
+psy_visual_stimulus_set_y(PsyVisualStimulus* stimulus, gfloat y);
+
+G_MODULE_EXPORT gfloat
+psy_visual_stimulus_get_z(PsyVisualStimulus* stimulus);
+G_MODULE_EXPORT void 
+psy_visual_stimulus_set_z(PsyVisualStimulus* stimulus, gfloat z);
+
+
 G_END_DECLS

--- a/psy/psy-window.c
+++ b/psy/psy-window.c
@@ -988,10 +988,11 @@ psy_window_set_projection_style(PsyWindow* self, gint style)
     }
 
     if (unit_style != 1) {
-        g_critical("%s: You should set PSY_WINDOW_PROJECTION_STYLE_PIXELS or "
-                "PSY_WINDOW_PROJECTION_STYLE_METER or"
-                "PSY_WINDOW_PROJECTION_STYLE_MILLIMETER or"
-                "PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES",
+        g_critical("%s: You should set exactly one of:\n"
+                "   - PSY_WINDOW_PROJECTION_STYLE_PIXELS or\n"
+                "   - PSY_WINDOW_PROJECTION_STYLE_METER or\n"
+                "   - PSY_WINDOW_PROJECTION_STYLE_MILLIMETER or\n"
+                "   - PSY_WINDOW_PROJECTION_STYLE_VISUAL_DEGREES",
                 __func__
                 );
         return;

--- a/tests/test-gtk-window.c
+++ b/tests/test-gtk-window.c
@@ -22,6 +22,9 @@ int g_nvertices = 10;
 gdouble g_radius = 50;
 gdouble g_amplitude = 25;
 gdouble g_frequency = 0.5;
+gdouble g_x = 0.0;
+gdouble g_y = 0.0;
+gdouble g_z = 0.0;
 
 char* g_origin = "center";
 char* g_units = "pixels";
@@ -35,6 +38,9 @@ static GOptionEntry entries[] = {
     {"vertices", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT, &g_nvertices, "The number of vertices of the circle", "number"},
     {"origin", 'o', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &g_origin, "The center C style or center", "c|center"},
     {"units", 'u', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &g_units, "The units of the coordinate system", "pix|m|mm|visdeg"},
+    {"x", 'x', G_OPTION_FLAG_NONE, G_OPTION_ARG_DOUBLE, &g_x, "The x-coordinate of the circle", "units depends on projection"},
+    {"y", 'y', G_OPTION_FLAG_NONE, G_OPTION_ARG_DOUBLE, &g_y, "The y-coordinate of the circle", "units depends on projection"},
+    {"z", 'z', G_OPTION_FLAG_NONE, G_OPTION_ARG_DOUBLE, &g_z, "The z-coordinate of the circle", "units depends on projection"},
     {0}
 };
 
@@ -128,7 +134,7 @@ gint get_window_style(void)
         g_warning("The units wasn't one of: %s, %s or %s, %s, defaulting to %s",
                 pixels, m, mm, visdeg, pixels
                 );
-        style |= PSY_WINDOW_PROJECTION_STYLE_CENTER;
+        style |= PSY_WINDOW_PROJECTION_STYLE_PIXELS;
     }
 
     return style;
@@ -163,7 +169,9 @@ int main(int argc, char**argv) {
     window_style = get_window_style();
     psy_window_set_projection_style(PSY_WINDOW(window), window_style);
 
-    PsyCircle* circle = psy_circle_new_full(PSY_WINDOW(window), 0, 0, .5, g_nvertices);
+    PsyCircle* circle = psy_circle_new_full(
+            PSY_WINDOW(window), g_x, g_y, g_radius, g_nvertices
+            );
     g_signal_connect(circle, "update", G_CALLBACK(update_circle), tp);
     g_signal_connect(circle, "started", G_CALLBACK(circle_started), tp);
     g_signal_connect(circle, "stopped", G_CALLBACK(circle_stopped), tp);


### PR DESCRIPTION
This commit adds x,y and z coordinate to instances of PsyVisualStimulus. In the test-gtk-window, one can use them. This makes it possible to draw stimuli away from the origin.