### PR TITLE
Consolidate draw order fixes #19

### DIFF
--- a/psy/psy-window.h
+++ b/psy/psy-window.h
@@ -131,6 +131,11 @@ psy_window_set_context(PsyWindow* window, PsyDrawingContext* context);
 G_MODULE_EXPORT PsyDrawingContext*
 psy_window_get_context(PsyWindow* window);
 
+G_MODULE_EXPORT void
+psy_window_swap_stimuli(PsyWindow* window, guint i1, guint i2);
+
+G_MODULE_EXPORT guint
+psy_window_get_num_stimuli(PsyWindow* window);
 
 G_END_DECLS
 


### PR DESCRIPTION
Currently I've opted to draw the stimuli in a specific order. The stimuli are placed on an array and the array is drawn in reverse. This has the effect of visual stimuli that are presented are presented like the playing cards on a deck. The stimulus on top of the stack is the one you see first. Other stimuli have by default the same z-coordinate (0), and depth testing makes sure they are not presented on top, but pixels not drawn by previous stimuli will still be visible.
If you want a stimulus to be always on top, you can still use the depth of the stimulus to override the default behavior.