### PR TITLE
Fix/ref counting

### DIFF
--- a/psy/gl/psy-gl-context.c
+++ b/psy/gl/psy-gl-context.c
@@ -44,7 +44,7 @@ psy_gl_context_finalize(GObject* object)
 {
     PsyGlContext* self = PSY_GL_CONTEXT(object);
 
-    G_OBJECT_CLASS(psy_gl_context_parent_class)->dispose(object);
+    G_OBJECT_CLASS(psy_gl_context_parent_class)->finalize(object);
 }
 
 static PsyProgram*

--- a/psy/gl/psy-gl-program.c
+++ b/psy/gl/psy-gl-program.c
@@ -77,6 +77,9 @@ psy_gl_program_dispose(GObject* object)
     PsyGlProgram* self = PSY_GL_PROGRAM(object);
     (void) self;
 
+    g_clear_object(&self->fragment_shader);
+    g_clear_object(&self->vertex_shader);
+
     G_OBJECT_CLASS(psy_gl_program_parent_class)->dispose(object);
 }
 

--- a/psy/gl/psy-gl-vbuffer.c
+++ b/psy/gl/psy-gl-vbuffer.c
@@ -85,7 +85,7 @@ psy_gl_vbuffer_finalize(GObject* object)
         self->vertex_array_id = 0;
     }
 
-    G_OBJECT_CLASS(psy_gl_vbuffer_parent_class)->dispose(object);
+    G_OBJECT_CLASS(psy_gl_vbuffer_parent_class)->finalize(object);
 }
 
 static void
@@ -270,7 +270,7 @@ psy_gl_vbuffer_class_init(PsyGlVBufferClass* class)
 /* ************ public functions ******************** */
 
 PsyGlVBuffer*
-psy_gl_vbuffer_new()
+psy_gl_vbuffer_new(void)
 {
     PsyGlVBuffer *gl_vbuffer = g_object_new(PSY_TYPE_GL_VBUFFER, NULL);
     return gl_vbuffer;

--- a/psy/meson.build
+++ b/psy/meson.build
@@ -150,7 +150,8 @@ gir = gnome.generate_gir(
     dependencies : [libpsy_dep],
 #    header : libpsy_public_header,
     install : true,
-    fatal_warnings :true
+    extra_args : ['--warn-all'],
+    fatal_warnings : true
 )
 gir_target = gir[0]
 typelib_target = gir[1]

--- a/psy/psy-artist.c
+++ b/psy/psy-artist.c
@@ -43,6 +43,23 @@ typedef enum {
 static GParamSpec*  artist_properties[NUM_PROPERTIES] = {0};
 
 static void
+artist_dispose(GObject* object)
+{
+    PsyArtistPrivate* priv = psy_artist_get_instance_private(object);
+
+    if (priv->window) {
+        g_object_unref(priv->window);
+        priv->window = NULL;
+    }
+    if (priv->stimulus) {
+        g_object_unref(priv->stimulus);
+        priv->window = NULL;
+    }
+
+    G_OBJECT_CLASS(psy_artist_parent_class)->dispose(object);
+}
+
+static void
 artist_set_property(GObject       *object,
                     guint          property_id,
                     const GValue  *value,
@@ -97,6 +114,8 @@ psy_artist_class_init(PsyArtistClass* klass)
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = artist_get_property;
     object_class->set_property = artist_set_property;
+
+    object_class->dispose = artist_dispose;
 
     /**
      * Artist:stimulus:

--- a/psy/psy-drawing-context.c
+++ b/psy/psy-drawing-context.c
@@ -118,7 +118,7 @@ psy_drawing_context_finalize(GObject* object)
     PsyDrawingContextPrivate* priv = psy_drawing_context_get_instance_private(self);
     (void) priv;
 
-    G_OBJECT_CLASS(psy_drawing_context_parent_class)->dispose(object);
+    G_OBJECT_CLASS(psy_drawing_context_parent_class)->finalize(object);
 }
 
 

--- a/psy/psy-program.c
+++ b/psy/psy-program.c
@@ -67,6 +67,9 @@ psy_program_dispose(GObject* object)
     PsyProgramPrivate* priv = psy_program_get_instance_private(self);
     (void) priv;
 
+    g_clear_object(&priv->vertex_shader);
+    g_clear_object(&priv->fragment_shader);
+
     G_OBJECT_CLASS(psy_program_parent_class)->dispose(object);
 }
 
@@ -77,7 +80,7 @@ psy_program_finalize(GObject* object)
     PsyProgramPrivate* priv = psy_program_get_instance_private(self);
     (void) priv;
 
-    G_OBJECT_CLASS(psy_program_parent_class)->dispose(object);
+    G_OBJECT_CLASS(psy_program_parent_class)->finalize(object);
 }
 
 

--- a/psy/psy-shader.c
+++ b/psy/psy-shader.c
@@ -79,9 +79,13 @@ psy_shader_finalize(GObject* object)
 {
     PsyShader* self = PSY_SHADER(object);
     PsyShaderPrivate* priv = psy_shader_get_instance_private(self);
-    (void) priv;
+    
+    if (priv->source) {
+        g_free(priv->source);
+        priv->source = NULL;
+    }
 
-    G_OBJECT_CLASS(psy_shader_parent_class)->dispose(object);
+    G_OBJECT_CLASS(psy_shader_parent_class)->finalize(object);
 }
 
 

--- a/psy/psy-stepping-stones.c
+++ b/psy/psy-stepping-stones.c
@@ -81,14 +81,6 @@ psy_stepping_stones_dispose (GObject *gobject)
             PSY_STEPPING_STONES(gobject)
             );
 
-    if (priv->steps) {
-        g_ptr_array_unref(priv->steps);
-        priv->steps = NULL;
-    }
-    if (priv->step_table) {
-        g_hash_table_unref(priv->step_table);
-        priv->step_table = NULL;
-    }
     G_OBJECT_CLASS (psy_stepping_stones_parent_class)->dispose (gobject);
 }
 
@@ -99,7 +91,14 @@ psy_stepping_stones_finalize (GObject *gobject)
             PSY_STEPPING_STONES(gobject)
             );
 
-    (void) priv;
+    if (priv->steps) {
+        g_ptr_array_unref(priv->steps);
+        priv->steps = NULL;
+    }
+    if (priv->step_table) {
+        g_hash_table_destroy(priv->step_table);
+        priv->step_table = NULL;
+    }
 
     G_OBJECT_CLASS (psy_stepping_stones_parent_class)->finalize (gobject);
 }
@@ -110,10 +109,12 @@ psy_stepping_stones_init(PsySteppingStones* self)
     PsySteppingStonesPrivate *priv = psy_stepping_stones_get_instance_private(
             self
             );
+
     priv->steps = g_ptr_array_new_full(
             64,
             g_object_unref
             );
+
     priv->step_table = g_hash_table_new_full(
             g_str_hash,
             g_str_equal,

--- a/psy/psy-stimulus.c
+++ b/psy/psy-stimulus.c
@@ -31,6 +31,19 @@ static GParamSpec  *stimulus_properties[NUM_PROPERTIES] = {0};
 static guint        stimulus_signals[NUM_SIGNALS]       = {0};
 
 static void
+psy_stimulus_dispose(GObject* object)
+{
+    PsyStimulusPrivate* priv =  psy_stimulus_get_instance_private(
+        PSY_STIMULUS(object)
+    );
+
+    g_clear_object(&priv->start_time);
+    g_clear_object(&priv->duration);
+
+    G_OBJECT_CLASS(psy_stimulus_parent_class)->dispose(object);
+}
+
+static void
 psy_stimulus_set_property (GObject      *object,
                            guint         property_id,
                            const GValue *value,
@@ -114,6 +127,7 @@ psy_stimulus_class_init(PsyStimulusClass* klass)
 
     object_class->set_property = psy_stimulus_set_property;
     object_class->get_property = psy_stimulus_get_property;
+    object_class->dispose      = psy_stimulus_dispose;
 
     klass->play = stimulus_play;
     klass->set_duration = stimulus_set_duration;

--- a/psy/psy-texture.c
+++ b/psy/psy-texture.c
@@ -136,7 +136,7 @@ psy_texture_init(PsyTexture* self)
 static void
 psy_texture_dispose(GObject* object)
 {
-    (void) object;
+    G_OBJECT_CLASS(psy_texture_parent_class)->dispose(object);
 }
 
 static void

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -122,6 +122,7 @@ psy_visual_stimulus_dispose(GObject* object)
             );
 
     g_clear_object(&priv->color);
+    g_clear_object(&priv->window);
 }
 
 static void
@@ -306,7 +307,7 @@ psy_visual_stimulus_class_init(PsyVisualStimulusClass* klass)
             );
 
     /**
-     * PsyVisualStimulus:color
+     * PsyVisualStimulus:color:
      *
      * The color `PsyColor` used to fill this object with
      */
@@ -370,7 +371,7 @@ psy_visual_stimulus_get_window(PsyVisualStimulus* stimulus)
 /**
  * psy_visual_stimulus_set_window:
  * @stimulus: a `PsyVisualStimulus`
- * @window: a `PsyWindow` to draw this stimulus on.
+ * @window:(transfer full): a `PsyWindow` to draw this stimulus on.
  *
  * Set the window on which this stimulus should be drawn.
  */
@@ -384,7 +385,7 @@ psy_visual_stimulus_set_window(PsyVisualStimulus* stimulus,
     g_return_if_fail(PSY_IS_WINDOW(window));
 
     g_clear_object(&priv->window);
-    priv->window = window;
+    priv->window = g_object_ref(window);
 }
 
 /*
@@ -627,8 +628,8 @@ psy_visual_stimulus_get_color(PsyVisualStimulus* self)
 /**
  * psy_visual_stimulus_set_color:
  * @self: an instance of `PsyVisualStimulus`
- * @color:(transfer full): An instance of `PsyVisualStimulus` that is going to
- *                         be used in order to fill the shape of the stimulus
+ * @color: An instance of `PsyVisualStimulus` that is going to
+ *         be used in order to fill the shape of the stimulus
  *
  * Set the fill color of the stimulus, this color is used to fill the stimulus
  */
@@ -640,7 +641,7 @@ psy_visual_stimulus_set_color(PsyVisualStimulus* self, PsyColor* color)
     g_return_if_fail(PSY_IS_VISUAL_STIMULUS(self) && PSY_IS_COLOR(color));
 
     g_clear_object(&priv->color);
-    priv->color = color;    
+    priv->color = g_object_ref(color);    
 }
 
 

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -123,6 +123,8 @@ psy_visual_stimulus_dispose(GObject* object)
 
     g_clear_object(&priv->color);
     g_clear_object(&priv->window);
+
+    G_OBJECT_CLASS(psy_visual_stimulus_parent_class)->dispose(object);
 }
 
 static void
@@ -307,7 +309,7 @@ psy_visual_stimulus_class_init(PsyVisualStimulusClass* klass)
             );
 
     /**
-     * PsyVisualStimulus:color:
+     * PsyVisualStimulus:color
      *
      * The color `PsyColor` used to fill this object with
      */

--- a/psy/psy-window.c
+++ b/psy/psy-window.c
@@ -189,11 +189,13 @@ psy_window_dispose(GObject* gobject)
     }
 
     if (priv->artists) {
-        g_hash_table_unref(priv->artists);
+        g_hash_table_destroy(priv->artists);
         priv->artists = NULL;
     }
 
+    g_clear_object(&priv->frame_dur);
     g_clear_object(&priv->context);
+    g_clear_object(&priv->projection_matrix);
 
     G_OBJECT_CLASS(psy_window_parent_class)->dispose(gobject);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,8 @@
 
+cc = meson.get_compiler('c')
+cunit_dep = dependency('cunit')
+
+
 window_prog = executable (
     '3dwindow_prog',
     files('window-prog.c'),
@@ -39,6 +43,12 @@ test_color = executable (
     'test-color',
     'test-color.c',
     dependencies : [psy_dep, mutest_dep]
+)
+
+test_ref_count = executable (
+    'test-ref-count',
+    'test-ref-count.c',
+    dependencies : [psy_dep, cunit_dep]
 )
 
 test('vector test', vector_test)

--- a/tests/test-ref-count.c
+++ b/tests/test-ref-count.c
@@ -1,0 +1,134 @@
+
+#include "psy-visual-stimulus.h"
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+
+#include <glib.h>
+#include <psy-color.h>
+#include <psy-circle.h>
+#include <backend_gtk/psy-gtk-window.h>
+
+gboolean verbose;
+
+GOptionEntry options[] = {
+    {"verbose", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &verbose, "Run the suite verbosely",""},
+    {0}
+};
+
+
+PsyWindow* window = NULL;
+
+static int
+init_window(void) {
+    window = PSY_WINDOW(psy_gtk_window_new());
+    if (window)
+        return 0;
+    else
+        return 1;
+}
+
+static int 
+destoy_window(void) {
+    g_object_unref(window);
+    window = NULL;
+    return 0;
+}
+
+static void
+ref_starts_with_one(void)
+{
+    PsyCircle* circle = g_object_new(PSY_TYPE_CIRCLE, "window", window, NULL);
+    PsyColor* color = g_object_new(PSY_TYPE_COLOR, NULL);
+    GObject* circle_gobj = G_OBJECT(circle);
+    GObject* color_gobj = G_OBJECT(color);
+
+    CU_ASSERT_EQUAL(circle_gobj->ref_count, 1);
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 1);
+
+    g_object_unref(circle);
+    g_object_unref(color);
+}
+
+static void
+ref_set_method(void)
+{
+    PsyCircle* circle = g_object_new(PSY_TYPE_CIRCLE, "window", window, NULL);
+    PsyColor* color = g_object_new(PSY_TYPE_COLOR, NULL);
+
+    // Cast to conveniently obtain the reference count
+    GObject* circle_gobj = G_OBJECT(circle);
+    GObject* color_gobj = G_OBJECT(color);
+
+    /*
+     * This is (transfer none), so the circle does not own the reference,
+     * but has a reference to it.
+     * Both we and the Circle should free it.
+     */ 
+    psy_visual_stimulus_set_color(PSY_VISUAL_STIMULUS(circle), color);
+    
+    CU_ASSERT_EQUAL(circle_gobj->ref_count, 1);
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 2);
+
+    // The circle disposes its reference to color
+    g_object_unref(circle);
+    
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 1);
+
+    g_object_unref(color);
+}
+
+static void
+ref_set_property(void)
+{
+    PsyCircle* circle = g_object_new(PSY_TYPE_CIRCLE, "window", window, NULL);
+    PsyColor* color = g_object_new(PSY_TYPE_COLOR, NULL);
+    GObject* circle_gobj = G_OBJECT(circle);
+    GObject* color_gobj = G_OBJECT(color);
+    
+    CU_ASSERT_EQUAL(circle_gobj->ref_count, 1);
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 1);
+
+     // Circle is owning a reference
+    g_object_set(
+            circle,
+            "color", color,
+            NULL
+            );
+    
+    CU_ASSERT_EQUAL(circle_gobj->ref_count, 1);
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 2);
+
+    g_object_unref(circle); // Circle disposes its reference on color
+    CU_ASSERT_EQUAL(color_gobj->ref_count, 1);
+
+    g_object_unref(color);
+}
+
+
+int main(int argc, char** argv) {
+
+    GOptionContext* context = g_option_context_new("");
+    g_option_context_add_main_entries(context, options, NULL);
+    GError* error = NULL;
+
+    if (!g_option_context_parse(context, &argc, &argv, &error)) {
+        g_printerr("Unable to parse options: %s\n", error->message);
+        g_option_context_free(context);
+        return EXIT_FAILURE;
+    }
+
+    CU_initialize_registry();
+
+    if (verbose)
+        CU_basic_set_mode(CU_BRM_VERBOSE);
+
+    CU_Suite* suite = CU_add_suite("test reference count", init_window, destoy_window);
+    CU_add_test(suite, "Object start with reference of 1", ref_starts_with_one);
+    CU_add_test(suite, "Objects ref set method", ref_set_method);
+    CU_add_test(suite, "Objects ref set property", ref_set_property);
+
+    CU_basic_run_tests();
+
+    CU_cleanup_registry();
+    g_option_context_free(context);
+}

--- a/tests/test-ref-count.py
+++ b/tests/test-ref-count.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import unittest
+import gi
+import logging
+import sys
+from sys import getrefcount
+gi.require_version('Psy', '0.1')
+from gi.repository import Psy  # noqa: E402
+
+
+class TestRefCount(unittest.TestCase):
+
+    def setUp(self):
+        '''Create a temporary window'''
+        self.win = Psy.GtkWindow()
+
+    def tearDown(self):
+        del self.win
+
+    def test_ref_count_starts_at_one(self):
+        color = Psy.Color()
+        circle = Psy.Circle(window=self.win)
+
+        self.assertEqual(getrefcount(color), 2)
+        self.assertEqual(getrefcount(circle), 2)
+
+        self.assertEqual(color.ref_count, 1)
+        self.assertEqual(circle.ref_count, 1)
+
+    def test_assignment_increments_python_reference(self):
+        c1 = Psy.Color()
+        c2 = c1
+
+        self.assertEqual(getrefcount(c2), 3)
+        self.assertEqual(c1.ref_count, 1)
+
+    def test_object_property(self):
+        color = Psy.Color()  # one ref to a color
+        circle = Psy.Circle(window=self.win)
+        circle2 = Psy.Circle(window=self.win)
+
+        circle.props.color = color
+        # The color is now owned by the circle
+        self.assertEqual(circle.props.color.ref_count, 2)
+
+        circle2.props.color = color
+        self.assertEqual(circle.props.color.ref_count, 3)
+        self.assertEqual(circle.props.color, circle2.props.color)
+
+        circle2.set_color(Psy.Color())
+        self.assertEqual(color.ref_count, 2)
+
+        circle.set_color(Psy.Color())
+        self.assertEqual(color.ref_count, 1)
+
+    def test_object_setter(self):
+        color = Psy.Color()
+        circle = Psy.Circle(window=self.win)
+
+        circle.set_color(color)
+        self.assertEqual(color.ref_count, 2)
+        self.assertEqual(circle.props.color.ref_count, 2)
+
+    def test_set_object_with_temp_objecr(self):
+        circle = Psy.Circle(window=self.win)
+        #circle.props.color = Psy.Color()
+        circle.set_color(Psy.Color())
+
+        # Only the circle has a reference
+        self.assertEqual(circle.props.color.ref_count, 1)
+
+    def test_set_object_in_constructor(self):
+        color = Psy.Color()
+        circle = Psy.Circle(window=self.win, color=color)
+        self.assertEqual(circle.props.color.ref_count, 2)
+
+        circle = Psy.Circle(window=self.win, color=Psy.Color())
+        self.assertEqual(circle.props.color.ref_count, 1)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(stream=sys.stderr)
+    logging.getLogger().setLevel(logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
This PR adds some tests for reference counting.
The C tests work almost perfectly, there are still some issues with similar tests in python. In the process a number of memory leaks have been fixed. 
The were a number of object that didn't properly chainup their finalize and dispose method, this was the main source of the memory leaks fixed in this PR.
Also, i've decided not to use (transfer full) for passing GObject derived classes to object via setter/getter of the set get property methods. As I don't precisely understand what code like this than does:
```python
# import as usual
c = Psy.Color()
r = Psy.Rectangle()
r.props.color = c  # transfer full
del c  # I think with transfer full this also deletes the instance at the rectangle
# So this might crash the Python interpreter, Which seems not so desireable :-(
r.props.color.r = 1
```
With transfer none I can claim a reference in the set_color_function of a VisualStimulus from which Rectangle is derived.
and then only python loses it reference, but a valid reference is then present in the instances of the VisualStimulus, which is then cleared on object destruction or setting a new color.