### PR TITLE
Fix/floats everywhere

### DIFF
--- a/psy/gl/psy-gl-program.c
+++ b/psy/gl/psy-gl-program.c
@@ -318,7 +318,7 @@ psy_gl_program_set_uniform_matrix_4(PsyProgram  *self,
                                     GError     **error)
 {
     PsyGlProgram *program = PSY_GL_PROGRAM(self);
-    GLdouble      elements[16];
+    GLfloat       elements[16];
     psy_matrix4_get_elements(matrix, elements);
 
     GLint location = glGetUniformLocation(program->object_id, name);
@@ -333,7 +333,7 @@ psy_gl_program_set_uniform_matrix_4(PsyProgram  *self,
         return;
     }
 
-    glUniformMatrix4dv(location, 1, GL_FALSE, elements);
+    glUniformMatrix4fv(location, 1, GL_FALSE, elements);
 }
 
 static void

--- a/psy/psy-artist.c
+++ b/psy/psy-artist.c
@@ -136,20 +136,20 @@ artist_draw(PsyArtist *self)
     GError           *error      = NULL;
     const gchar      *model_name = "model";
 
-    gdouble x = psy_visual_stimulus_get_x(priv->stimulus);
-    gdouble y = psy_visual_stimulus_get_y(priv->stimulus);
-    gdouble z = psy_visual_stimulus_get_z(priv->stimulus);
+    gfloat x = psy_visual_stimulus_get_x(priv->stimulus);
+    gfloat y = psy_visual_stimulus_get_y(priv->stimulus);
+    gfloat z = psy_visual_stimulus_get_z(priv->stimulus);
 
     PsyVector3 *translation
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
 
-    gdouble scale_x = psy_visual_stimulus_get_scale_x(priv->stimulus);
-    gdouble scale_y = psy_visual_stimulus_get_scale_y(priv->stimulus);
+    gfloat scale_x = psy_visual_stimulus_get_scale_x(priv->stimulus);
+    gfloat scale_y = psy_visual_stimulus_get_scale_y(priv->stimulus);
 
     PsyVector3 *scale_vec
         = g_object_new(PSY_TYPE_VECTOR3, "x", scale_x, "y", scale_y, NULL);
 
-    gdouble rotation_degrees = psy_visual_stimulus_get_rotation(priv->stimulus);
+    gfloat rotation_degrees = psy_visual_stimulus_get_rotation(priv->stimulus);
     PsyVector3 *z_axis
         = g_object_new(PSY_TYPE_VECTOR3, "x", 0.0, "y", 0.0, "z", -1.0, NULL);
 

--- a/psy/psy-matrix4.cpp
+++ b/psy/psy-matrix4.cpp
@@ -19,8 +19,8 @@
 typedef struct _PsyMatrix4 PsyMatrix4;
 
 struct _PsyMatrix4 {
-    GObject       parent_instance;
-    glm::dmat4x4 *matrix;
+    GObject      parent_instance;
+    glm::mat4x4 *matrix;
 };
 
 G_DEFINE_TYPE(PsyMatrix4, psy_matrix4, G_TYPE_OBJECT)
@@ -39,7 +39,7 @@ static GParamSpec *obj_properties[N_PROPERTIES] = {
 static void
 psy_matrix4_init(PsyMatrix4 *self)
 {
-    self->matrix = new glm::dmat4x4();
+    self->matrix = new glm::mat4x4();
 }
 
 static void
@@ -127,7 +127,6 @@ psy_matrix4_class_init(PsyMatrix4Class *klass)
         gobject_class, N_PROPERTIES, obj_properties);
 }
 
-
 /* ************* public functions ************* */
 
 /**
@@ -181,12 +180,12 @@ psy_matrix4_new_identity()
  *          orthographic projection.
  */
 PsyMatrix4 *
-psy_matrix4_new_ortographic(gdouble left,
-                            gdouble right,
-                            gdouble bottom,
-                            gdouble top,
-                            gdouble z_near,
-                            gdouble z_far)
+psy_matrix4_new_ortographic(gfloat left,
+                            gfloat right,
+                            gfloat bottom,
+                            gfloat top,
+                            gfloat z_near,
+                            gfloat z_far)
 {
     PsyMatrix4 *ret = psy_matrix4_new();
 
@@ -211,10 +210,10 @@ psy_matrix4_new_ortographic(gdouble left,
  *          projection.
  */
 PsyMatrix4 *
-psy_matrix4_new_perspective(gdouble fovy,
-                            gdouble aspect,
-                            gdouble z_near,
-                            gdouble z_far)
+psy_matrix4_new_perspective(gfloat fovy,
+                            gfloat aspect,
+                            gfloat z_near,
+                            gfloat z_far)
 {
     PsyMatrix4 *ret = psy_matrix4_new();
 
@@ -248,7 +247,7 @@ psy_matrix4_set_identity(PsyMatrix4 *self)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self));
 
-    *self->matrix = glm::dmat4x4(1);
+    *self->matrix = glm::mat4x4(1);
 }
 
 /**
@@ -266,7 +265,7 @@ psy_matrix4_is_identity(PsyMatrix4 *self)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), FALSE);
 
-    return *self->matrix == glm::dmat4x4(1);
+    return *self->matrix == glm::mat4x4(1);
 }
 
 /**
@@ -281,7 +280,7 @@ psy_matrix4_set_null(PsyMatrix4 *self)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self));
 
-    *self->matrix = glm::dmat4x4(0);
+    *self->matrix = glm::mat4x4(0);
 }
 
 /**
@@ -299,7 +298,7 @@ psy_matrix4_is_null(PsyMatrix4 *self)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), FALSE);
 
-    return *self->matrix == glm::dmat4x4(0);
+    return *self->matrix == glm::mat4x4(0);
 }
 
 /**
@@ -310,7 +309,7 @@ psy_matrix4_is_null(PsyMatrix4 *self)
  * Returns :(transfer full): The result of self + s
  */
 PsyMatrix4 *
-psy_matrix4_add_s(PsyMatrix4 *self, gdouble scalar)
+psy_matrix4_add_s(PsyMatrix4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), NULL);
 
@@ -353,7 +352,7 @@ psy_matrix4_add(PsyMatrix4 *self, PsyMatrix4 *other)
  *         that is the result of self - scalar.
  */
 PsyMatrix4 *
-psy_matrix4_sub_s(PsyMatrix4 *self, gdouble scalar)
+psy_matrix4_sub_s(PsyMatrix4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), NULL);
 
@@ -399,7 +398,7 @@ psy_matrix4_sub(PsyMatrix4 *self, PsyMatrix4 *other)
  *         that is the result of self * scalar.
  */
 PsyMatrix4 *
-psy_matrix4_mul_s(PsyMatrix4 *self, gdouble scalar)
+psy_matrix4_mul_s(PsyMatrix4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), NULL);
     PsyMatrix4 *ret = psy_matrix4_new();
@@ -513,7 +512,7 @@ psy_matrix4_as_string(PsyMatrix4 *self)
  *
  * Returns (transfer none): a pointer to the data.
  */
-const gdouble *
+const gfloat *
 psy_matrix4_ptr(PsyMatrix4 *self)
 {
     g_return_val_if_fail(PSY_IS_MATRIX4(self), NULL);
@@ -529,11 +528,11 @@ psy_matrix4_ptr(PsyMatrix4 *self)
  * Returns the matrix in elements in column major order.
  */
 void
-psy_matrix4_get_elements(PsyMatrix4 *self, gdouble *elements)
+psy_matrix4_get_elements(PsyMatrix4 *self, gfloat *elements)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self));
-    gdouble       *out = &elements[0];
-    const gdouble *in  = glm::value_ptr(*(self->matrix));
+    gfloat       *out = &elements[0];
+    const gfloat *in  = glm::value_ptr(*(self->matrix));
     for (; out < &elements[16]; in++, out++)
         *out = (gfloat) *in;
 }
@@ -547,12 +546,12 @@ psy_matrix4_get_elements(PsyMatrix4 *self, gdouble *elements)
  * Rotates @self @degrees around @axis
  */
 void
-psy_matrix4_rotate(PsyMatrix4 *self, gdouble degrees, PsyVector3 *axis)
+psy_matrix4_rotate(PsyMatrix4 *self, gfloat degrees, PsyVector3 *axis)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self) && PSY_IS_VECTOR3(axis));
 
-    const glm::dvec3& vec = psy_vector3_get_priv_reference(axis);
-    *self->matrix         = glm::rotate(*self->matrix, degrees, vec);
+    const glm::vec3& vec = psy_vector3_get_priv_reference(axis);
+    *self->matrix        = glm::rotate(*self->matrix, degrees, vec);
 }
 
 /**
@@ -567,8 +566,8 @@ psy_matrix4_scale(PsyMatrix4 *self, PsyVector3 *vector)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self) && PSY_IS_VECTOR3(vector));
 
-    const glm::dvec3& vec = psy_vector3_get_priv_reference(vector);
-    *self->matrix         = glm::scale(*self->matrix, vec);
+    const glm::vec3& vec = psy_vector3_get_priv_reference(vector);
+    *self->matrix        = glm::scale(*self->matrix, vec);
 }
 
 /**
@@ -583,6 +582,6 @@ psy_matrix4_translate(PsyMatrix4 *self, PsyVector3 *vector)
 {
     g_return_if_fail(PSY_IS_MATRIX4(self) && PSY_IS_VECTOR3(vector));
 
-    const glm::dvec3& vec = psy_vector3_get_priv_reference(vector);
-    *self->matrix         = glm::translate(*self->matrix, vec);
+    const glm::vec3& vec = psy_vector3_get_priv_reference(vector);
+    *self->matrix        = glm::translate(*self->matrix, vec);
 }

--- a/psy/psy-matrix4.h
+++ b/psy/psy-matrix4.h
@@ -19,18 +19,18 @@ G_MODULE_EXPORT PsyMatrix4 *
 psy_matrix4_new_identity(void);
 
 G_MODULE_EXPORT PsyMatrix4 *
-psy_matrix4_new_ortographic(gdouble left,
-                            gdouble right,
-                            gdouble bottom,
-                            gdouble top,
-                            gdouble z_near,
-                            gdouble z_far);
+psy_matrix4_new_ortographic(gfloat left,
+                            gfloat right,
+                            gfloat bottom,
+                            gfloat top,
+                            gfloat z_near,
+                            gfloat z_far);
 
 G_MODULE_EXPORT PsyMatrix4 *
-psy_matrix4_new_perspective(gdouble fovy,
-                            gdouble aspect,
-                            gdouble near,
-                            gdouble far);
+psy_matrix4_new_perspective(gfloat fovy,
+                            gfloat aspect,
+                            gfloat near,
+                            gfloat far);
 
 G_MODULE_EXPORT void
 psy_matrix4_destroy(PsyMatrix4 *v);
@@ -47,17 +47,17 @@ G_MODULE_EXPORT gboolean
 psy_matrix4_is_null(PsyMatrix4 *self);
 
 G_MODULE_EXPORT PsyMatrix4 *
-psy_matrix4_add_s(PsyMatrix4 *self, gdouble scalar);
+psy_matrix4_add_s(PsyMatrix4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyMatrix4 *
 psy_matrix4_add(PsyMatrix4 *self, PsyMatrix4 *other);
 
 G_MODULE_EXPORT PsyMatrix4 *
-psy_matrix4_sub_s(PsyMatrix4 *self, gdouble scalar);
+psy_matrix4_sub_s(PsyMatrix4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyMatrix4 *
 psy_matrix4_sub(PsyMatrix4 *self, PsyMatrix4 *other);
 
 G_MODULE_EXPORT PsyMatrix4 *
-psy_matrix4_mul_s(PsyMatrix4 *self, gdouble scalar);
+psy_matrix4_mul_s(PsyMatrix4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyMatrix4 *
 psy_matrix4_mul(PsyMatrix4 *self, PsyMatrix4 *other);
 
@@ -69,14 +69,14 @@ psy_matrix4_not_equals(PsyMatrix4 *self, PsyMatrix4 *other);
 G_MODULE_EXPORT gchar *
 psy_matrix4_as_string(PsyMatrix4 *self);
 
-G_MODULE_EXPORT const gdouble *
+G_MODULE_EXPORT const gfloat *
 psy_matrix4_ptr(PsyMatrix4 *self);
 
 G_MODULE_EXPORT void
-psy_matrix4_get_elements(PsyMatrix4 *self, gdouble *elements);
+psy_matrix4_get_elements(PsyMatrix4 *self, gfloat *elements);
 
 G_MODULE_EXPORT void
-psy_matrix4_rotate(PsyMatrix4 *self, gdouble degrees, PsyVector3 *axis);
+psy_matrix4_rotate(PsyMatrix4 *self, gfloat degrees, PsyVector3 *axis);
 
 G_MODULE_EXPORT void
 psy_matrix4_scale(PsyMatrix4 *self, PsyVector3 *vector);

--- a/psy/psy-vector3-private.h
+++ b/psy/psy-vector3-private.h
@@ -3,8 +3,8 @@
 
 #include "psy-vector3.h"
 
-glm::dvec3&
+glm::vec3&
 psy_vector3_get_priv_reference(PsyVector3 *self);
 
-glm::dvec3 *
+glm::vec3 *
 psy_vector3_get_priv_pointer(PsyVector3 *self);

--- a/psy/psy-vector3.cpp
+++ b/psy/psy-vector3.cpp
@@ -7,8 +7,8 @@
 #include "psy-vector3.h"
 
 typedef struct _PsyVector3 {
-    GObject     obj;
-    glm::dvec3 *vector;
+    GObject    obj;
+    glm::vec3 *vector;
 } PsyVector3;
 
 G_DEFINE_TYPE(PsyVector3, psy_vector3, G_TYPE_OBJECT)
@@ -31,7 +31,7 @@ static GParamSpec *obj_properties[N_PROPERTIES] = {
 static void
 psy_vector3_init(PsyVector3 *self)
 {
-    self->vector = new glm::dvec3();
+    self->vector = new glm::vec3();
 }
 
 static void
@@ -54,13 +54,13 @@ psy_vector3_set_property(GObject      *object,
 
     switch ((PsyVector3Property) prop_id) {
     case PROP_X:
-        (*self->vector)[0] = g_value_get_double(value);
+        (*self->vector)[0] = g_value_get_float(value);
         break;
     case PROP_Y:
-        (*self->vector)[1] = g_value_get_double(value);
+        (*self->vector)[1] = g_value_get_float(value);
         break;
     case PROP_Z:
-        (*self->vector)[2] = g_value_get_double(value);
+        (*self->vector)[2] = g_value_get_float(value);
         break;
         //        case PROP_VALUES:
         //            g_assert(G_VALUE_HOLDS_BOXED(value));
@@ -82,16 +82,16 @@ psy_vector3_get_property(GObject    *object,
 
     switch ((PsyVector3Property) prop_id) {
     case PROP_X:
-        g_value_set_double(value, (*self->vector)[0]);
+        g_value_set_float(value, (*self->vector)[0]);
         break;
     case PROP_Y:
-        g_value_set_double(value, (*self->vector)[1]);
+        g_value_set_float(value, (*self->vector)[1]);
         break;
     case PROP_Z:
-        g_value_set_double(value, (*self->vector)[2]);
+        g_value_set_float(value, (*self->vector)[2]);
         break;
     case PROP_MAGNITUDE:
-        g_value_set_double(value, psy_vector3_get_magnitude(self));
+        g_value_set_float(value, psy_vector3_get_magnitude(self));
         break;
     case PROP_UNIT:
         g_value_take_object(value, psy_vector3_unit(self));
@@ -115,38 +115,38 @@ psy_vector3_class_init(PsyVector3Class *klass)
     gobject_class->get_property = psy_vector3_get_property;
     gobject_class->finalize     = psy_vector3_finalize;
 
-    obj_properties[PROP_X] = g_param_spec_double("x",
-                                                 "X",
-                                                 "The x value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_X] = g_param_spec_float("x",
+                                                "X",
+                                                "The x value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
-    obj_properties[PROP_Y] = g_param_spec_double("y",
-                                                 "Y",
-                                                 "The y value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_Y] = g_param_spec_float("y",
+                                                "Y",
+                                                "The y value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
-    obj_properties[PROP_Z] = g_param_spec_double("z",
-                                                 "Z",
-                                                 "The z value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_Z] = g_param_spec_float("z",
+                                                "Z",
+                                                "The z value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
     obj_properties[PROP_MAGNITUDE]
-        = g_param_spec_double("magnitude",
-                              "magnitude",
-                              "The magnitude of the vector.",
-                              0,
-                              G_MAXDOUBLE,
-                              0,
-                              G_PARAM_READABLE);
+        = g_param_spec_float("magnitude",
+                             "magnitude",
+                             "The magnitude of the vector.",
+                             0,
+                             G_MAXFLOAT,
+                             0,
+                             G_PARAM_READABLE);
 
     obj_properties[PROP_UNIT]
         = g_param_spec_object("unit",
@@ -195,7 +195,7 @@ psy_vector3_new()
  *          will be set to 0.0, if n > 0 the values after 3 will be ignored.
  */
 PsyVector3 *
-psy_vector3_new_data(gsize n, gdouble *values)
+psy_vector3_new_data(gsize n, gfloat *values)
 {
     PsyVector3 *ret = psy_vector3_new();
     g_warn_if_fail(n <= 3);
@@ -229,7 +229,7 @@ psy_vector3_set_null(PsyVector3 *self)
 {
     g_return_if_fail(PSY_IS_VECTOR3(self));
 
-    *self->vector = glm::dvec3(0);
+    *self->vector = glm::vec3(0);
 }
 
 /**
@@ -245,7 +245,7 @@ psy_vector3_is_null(PsyVector3 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), FALSE);
 
-    return *self->vector == glm::dvec3(0);
+    return *self->vector == glm::vec3(0);
 }
 
 /**
@@ -257,7 +257,7 @@ psy_vector3_is_null(PsyVector3 *self)
  * Returns: the maginitude of the vector
  */
 
-gdouble
+gfloat
 psy_vector3_get_magnitude(PsyVector3 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), 0);
@@ -319,7 +319,7 @@ psy_vector3_negate(PsyVector3 *self)
  * Returns:(transfer full): a vector with @scalar.
  */
 PsyVector3 *
-psy_vector3_add_s(PsyVector3 *self, gdouble scalar)
+psy_vector3_add_s(PsyVector3 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), NULL);
 
@@ -358,7 +358,7 @@ psy_vector3_add(PsyVector3 *self, PsyVector3 *other)
  * Returns:(transfer full): the result of @self - @scalar
  */
 PsyVector3 *
-psy_vector3_sub_s(PsyVector3 *self, gdouble scalar)
+psy_vector3_sub_s(PsyVector3 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), NULL);
     PsyVector3 *ret = PSY_VECTOR3(psy_vector3_new());
@@ -395,7 +395,7 @@ psy_vector3_sub(PsyVector3 *self, PsyVector3 *other)
  * Returns:(transfer full): The result of @self * @scalar
  */
 PsyVector3 *
-psy_vector3_mul_s(PsyVector3 *self, gdouble scalar)
+psy_vector3_mul_s(PsyVector3 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), NULL);
     PsyVector3 *ret = PSY_VECTOR3(psy_vector3_new());
@@ -435,7 +435,7 @@ psy_vector3_mul(PsyVector3 *self, PsyVector3 *other)
  *
  * Returns: The result of @self . @other
  */
-gdouble
+gfloat
 psy_vector3_dot(PsyVector3 *self, PsyVector3 *other)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), 0.0);
@@ -488,7 +488,7 @@ psy_vector3_not_equals(PsyVector3 *self, PsyVector3 *other)
  *
  * Returns: a pointer to the data
  */
-const gdouble *
+const gfloat *
 psy_vector3_ptr(PsyVector3 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), NULL);
@@ -500,14 +500,14 @@ psy_vector3_ptr(PsyVector3 *self)
  * psy_vector3_get_values:
  * @self: An instance of `PsyVector` whose elements you'd like to get
  *
- * Returns:(transfer full)(element-type gdouble): the elements of the vector
+ * Returns:(transfer full)(element-type gfloat): the elements of the vector
  */
 GArray *
 psy_vector3_get_values(PsyVector3 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR3(self), NULL);
 
-    GArray *ret = g_array_sized_new(FALSE, FALSE, sizeof(gdouble), 3);
+    GArray *ret = g_array_sized_new(FALSE, FALSE, sizeof(gfloat), 3);
     g_array_append_vals(ret, psy_vector3_ptr(self), 3);
 
     return ret;
@@ -516,7 +516,7 @@ psy_vector3_get_values(PsyVector3 *self)
 /**
  * psy_vector3_set_values:
  * @self: an instance of `PsyVector3` whose values to set
- * @array:(transfer none)(element-type gdouble): an
+ * @array:(transfer none)(element-type gfloat): an
  *        array with 3 value to set this array with
  *
  * Set the values of @self
@@ -527,8 +527,8 @@ psy_vector3_set_values(PsyVector3 *self, GArray *array)
     g_return_if_fail(PSY_IS_VECTOR3(self));
     g_return_if_fail(array);
 
-    gdouble *in  = reinterpret_cast<gdouble *>(array->data);
-    guint    min = array->len > 3 ? 3 : array->len;
+    gfloat *in  = reinterpret_cast<gfloat *>(array->data);
+    guint   min = array->len > 3 ? 3 : array->len;
 
     for (guint i = 0; i < min; i++)
         (*self->vector)[i] = in[i];
@@ -552,9 +552,9 @@ psy_vector3_as_string(PsyVector3 *self)
 /**
  * psy_vector3_get_priv_reference:(skip)
  *
- * Returns: the private implementation of the vector a glm::dvec3
+ * Returns: the private implementation of the vector a glm::vec3
  */
-glm::dvec3&
+glm::vec3&
 psy_vector3_get_priv_reference(PsyVector3 *self)
 {
     g_assert(PSY_IS_VECTOR3(self));
@@ -565,7 +565,7 @@ psy_vector3_get_priv_reference(PsyVector3 *self)
 /**
  * psy_vector3_get_priv_pointer:(skip)
  */
-glm::dvec3 *
+glm::vec3 *
 psy_vector3_get_priv_pointer(PsyVector3 *self)
 {
     g_assert(PSY_IS_VECTOR3(self));

--- a/psy/psy-vector3.h
+++ b/psy/psy-vector3.h
@@ -13,12 +13,12 @@ G_DECLARE_FINAL_TYPE(PsyVector3, psy_vector3, PSY, VECTOR3, GObject)
 G_MODULE_EXPORT PsyVector3 *
 psy_vector3_new(void);
 G_MODULE_EXPORT PsyVector3 *
-psy_vector3_new_data(gsize n, gdouble *values);
+psy_vector3_new_data(gsize n, gfloat *values);
 
 G_MODULE_EXPORT void
 psy_vector3_destroy(PsyVector3 *self);
 
-G_MODULE_EXPORT gdouble
+G_MODULE_EXPORT gfloat
 psy_vector3_get_magnitude(PsyVector3 *self);
 
 G_MODULE_EXPORT PsyVector3 *
@@ -32,20 +32,20 @@ G_MODULE_EXPORT gboolean
 psy_vector3_is_null(PsyVector3 *self);
 
 G_MODULE_EXPORT PsyVector3 *
-psy_vector3_add_s(PsyVector3 *self, gdouble scalar);
+psy_vector3_add_s(PsyVector3 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector3 *
 psy_vector3_add(PsyVector3 *self, PsyVector3 *other);
 
 G_MODULE_EXPORT PsyVector3 *
-psy_vector3_sub_s(PsyVector3 *self, gdouble scalar);
+psy_vector3_sub_s(PsyVector3 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector3 *
 psy_vector3_sub(PsyVector3 *self, PsyVector3 *other);
 
 G_MODULE_EXPORT PsyVector3 *
-psy_vector3_mul_s(PsyVector3 *self, gdouble scalar);
+psy_vector3_mul_s(PsyVector3 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector3 *
 psy_vector3_mul(PsyVector3 *self, PsyVector3 *other);
-G_MODULE_EXPORT gdouble
+G_MODULE_EXPORT gfloat
 psy_vector3_dot(PsyVector3 *self, PsyVector3 *other);
 
 G_MODULE_EXPORT gboolean
@@ -53,7 +53,7 @@ psy_vector3_equals(PsyVector3 *self, PsyVector3 *other);
 G_MODULE_EXPORT gboolean
 psy_vector3_not_equals(PsyVector3 *self, PsyVector3 *other);
 
-G_MODULE_EXPORT const gdouble *
+G_MODULE_EXPORT const gfloat *
 psy_vector3_ptr(PsyVector3 *self);
 
 G_MODULE_EXPORT GArray *

--- a/psy/psy-vector4.cpp
+++ b/psy/psy-vector4.cpp
@@ -7,8 +7,8 @@
 #include "psy-vector4.h"
 
 typedef struct _PsyVector4 {
-    GObject     obj;
-    glm::dvec4 *vector;
+    GObject    obj;
+    glm::vec4 *vector;
 } PsyVector4;
 
 G_DEFINE_TYPE(PsyVector4, psy_vector4, G_TYPE_OBJECT)
@@ -32,7 +32,7 @@ static GParamSpec *obj_properties[N_PROPERTIES] = {
 static void
 psy_vector4_init(PsyVector4 *self)
 {
-    self->vector = new glm::dvec4();
+    self->vector = new glm::vec4();
 }
 
 static void
@@ -55,16 +55,16 @@ psy_vector4_set_property(GObject      *object,
 
     switch ((PsyVector4Property) prop_id) {
     case PROP_X:
-        (*self->vector)[0] = g_value_get_double(value);
+        (*self->vector)[0] = g_value_get_float(value);
         break;
     case PROP_Y:
-        (*self->vector)[1] = g_value_get_double(value);
+        (*self->vector)[1] = g_value_get_float(value);
         break;
     case PROP_Z:
-        (*self->vector)[2] = g_value_get_double(value);
+        (*self->vector)[2] = g_value_get_float(value);
         break;
     case PROP_W:
-        (*self->vector)[3] = g_value_get_double(value);
+        (*self->vector)[3] = g_value_get_float(value);
         break;
         //        case PROP_VALUES:
         //            g_assert(G_VALUE_HOLDS_BOXED(value));
@@ -86,19 +86,19 @@ psy_vector4_get_property(GObject    *object,
 
     switch ((PsyVector4Property) prop_id) {
     case PROP_X:
-        g_value_set_double(value, (*self->vector)[0]);
+        g_value_set_float(value, (*self->vector)[0]);
         break;
     case PROP_Y:
-        g_value_set_double(value, (*self->vector)[1]);
+        g_value_set_float(value, (*self->vector)[1]);
         break;
     case PROP_Z:
-        g_value_set_double(value, (*self->vector)[2]);
+        g_value_set_float(value, (*self->vector)[2]);
         break;
     case PROP_W:
-        g_value_set_double(value, (*self->vector)[3]);
+        g_value_set_float(value, (*self->vector)[3]);
         break;
     case PROP_MAGNITUDE:
-        g_value_set_double(value, psy_vector4_get_magnitude(self));
+        g_value_set_float(value, psy_vector4_get_magnitude(self));
         break;
     case PROP_UNIT:
         g_value_take_object(value, psy_vector4_unit(self));
@@ -122,46 +122,46 @@ psy_vector4_class_init(PsyVector4Class *klass)
     gobject_class->get_property = psy_vector4_get_property;
     gobject_class->finalize     = psy_vector4_finalize;
 
-    obj_properties[PROP_X] = g_param_spec_double("x",
-                                                 "X",
-                                                 "The x value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_X] = g_param_spec_float("x",
+                                                "X",
+                                                "The x value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
-    obj_properties[PROP_Y] = g_param_spec_double("y",
-                                                 "Y",
-                                                 "The y value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_Y] = g_param_spec_float("y",
+                                                "Y",
+                                                "The y value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
-    obj_properties[PROP_Z] = g_param_spec_double("z",
-                                                 "Z",
-                                                 "The z value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_Z] = g_param_spec_float("z",
+                                                "Z",
+                                                "The z value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
-    obj_properties[PROP_W] = g_param_spec_double("w",
-                                                 "W",
-                                                 "The w value of the vector",
-                                                 -G_MAXDOUBLE,
-                                                 G_MAXDOUBLE,
-                                                 0,
-                                                 G_PARAM_READWRITE);
+    obj_properties[PROP_W] = g_param_spec_float("w",
+                                                "W",
+                                                "The w value of the vector",
+                                                -G_MAXFLOAT,
+                                                G_MAXFLOAT,
+                                                0,
+                                                G_PARAM_READWRITE);
 
     obj_properties[PROP_MAGNITUDE]
-        = g_param_spec_double("magnitude",
-                              "magnitude",
-                              "The magnitude of the vector.",
-                              0,
-                              G_MAXDOUBLE,
-                              0,
-                              G_PARAM_READABLE);
+        = g_param_spec_float("magnitude",
+                             "magnitude",
+                             "The magnitude of the vector.",
+                             0,
+                             G_MAXFLOAT,
+                             0,
+                             G_PARAM_READABLE);
 
     obj_properties[PROP_UNIT]
         = g_param_spec_object("unit",
@@ -210,7 +210,7 @@ psy_vector4_new()
  *          will be set to 0.0, if n > 0 the values after 4 will be ignored.
  */
 PsyVector4 *
-psy_vector4_new_data(gsize n, gdouble *values)
+psy_vector4_new_data(gsize n, gfloat *values)
 {
     PsyVector4 *ret = psy_vector4_new();
     g_warn_if_fail(n <= 4);
@@ -244,7 +244,7 @@ psy_vector4_set_null(PsyVector4 *self)
 {
     g_return_if_fail(PSY_IS_VECTOR4(self));
 
-    *self->vector = glm::dvec4(0);
+    *self->vector = glm::vec4(0);
 }
 
 /**
@@ -260,7 +260,7 @@ psy_vector4_is_null(PsyVector4 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), FALSE);
 
-    return *self->vector == glm::dvec4(0);
+    return *self->vector == glm::vec4(0);
 }
 
 /**
@@ -272,7 +272,7 @@ psy_vector4_is_null(PsyVector4 *self)
  * Returns: the maginitude of the vector
  */
 
-gdouble
+gfloat
 psy_vector4_get_magnitude(PsyVector4 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), 0);
@@ -334,7 +334,7 @@ psy_vector4_negate(PsyVector4 *self)
  * Returns:(transfer full): a vector with @scalar.
  */
 PsyVector4 *
-psy_vector4_add_s(PsyVector4 *self, gdouble scalar)
+psy_vector4_add_s(PsyVector4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), NULL);
 
@@ -373,7 +373,7 @@ psy_vector4_add(PsyVector4 *self, PsyVector4 *other)
  * Returns:(transfer full): the result of @self - @scalar
  */
 PsyVector4 *
-psy_vector4_sub_s(PsyVector4 *self, gdouble scalar)
+psy_vector4_sub_s(PsyVector4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), NULL);
     PsyVector4 *ret = PSY_VECTOR4(psy_vector4_new());
@@ -410,7 +410,7 @@ psy_vector4_sub(PsyVector4 *self, PsyVector4 *other)
  * Returns:(transfer full): The result of @self * @scalar
  */
 PsyVector4 *
-psy_vector4_mul_s(PsyVector4 *self, gdouble scalar)
+psy_vector4_mul_s(PsyVector4 *self, gfloat scalar)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), NULL);
     PsyVector4 *ret = PSY_VECTOR4(psy_vector4_new());
@@ -450,7 +450,7 @@ psy_vector4_mul(PsyVector4 *self, PsyVector4 *other)
  *
  * Returns: The result of @self . @other
  */
-gdouble
+gfloat
 psy_vector4_dot(PsyVector4 *self, PsyVector4 *other)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), 0.0);
@@ -503,7 +503,7 @@ psy_vector4_not_equals(PsyVector4 *self, PsyVector4 *other)
  *
  * Returns: a pointer to the data
  */
-const gdouble *
+const gfloat *
 psy_vector4_ptr(PsyVector4 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), NULL);
@@ -515,14 +515,14 @@ psy_vector4_ptr(PsyVector4 *self)
  * psy_vector4_get_values:
  * @self: An instance of `PsyVector` whose elements you'd like to get
  *
- * Returns:(transfer full)(element-type gdouble): the elements of the vector
+ * Returns:(transfer full)(element-type gfloat): the elements of the vector
  */
 GArray *
 psy_vector4_get_values(PsyVector4 *self)
 {
     g_return_val_if_fail(PSY_IS_VECTOR4(self), NULL);
 
-    GArray *ret = g_array_sized_new(FALSE, FALSE, sizeof(gdouble), 4);
+    GArray *ret = g_array_sized_new(FALSE, FALSE, sizeof(gfloat), 4);
     g_array_append_vals(ret, psy_vector4_ptr(self), 4);
 
     return ret;
@@ -531,7 +531,7 @@ psy_vector4_get_values(PsyVector4 *self)
 /**
  * psy_vector4_set_values:
  * @self: an instance of `PsyVector4` whose values to set
- * @array:(transfer none)(element-type gdouble): an
+ * @array:(transfer none)(element-type gfloat): an
  *        array with 4 value to set this array with
  *
  * Set the values of @self
@@ -542,8 +542,8 @@ psy_vector4_set_values(PsyVector4 *self, GArray *array)
     g_return_if_fail(PSY_IS_VECTOR4(self));
     g_return_if_fail(array);
 
-    gdouble *in  = reinterpret_cast<gdouble *>(array->data);
-    guint    min = array->len > 4 ? 4 : array->len;
+    gfloat *in  = reinterpret_cast<gfloat *>(array->data);
+    guint   min = array->len > 4 ? 4 : array->len;
 
     for (guint i = 0; i < min; i++)
         (*self->vector)[i] = in[i];

--- a/psy/psy-vector4.h
+++ b/psy/psy-vector4.h
@@ -13,12 +13,12 @@ G_DECLARE_FINAL_TYPE(PsyVector4, psy_vector4, PSY, VECTOR4, GObject)
 G_MODULE_EXPORT PsyVector4 *
 psy_vector4_new(void);
 G_MODULE_EXPORT PsyVector4 *
-psy_vector4_new_data(gsize n, gdouble *values);
+psy_vector4_new_data(gsize n, gfloat *values);
 
 G_MODULE_EXPORT void
 psy_vector4_destroy(PsyVector4 *self);
 
-G_MODULE_EXPORT gdouble
+G_MODULE_EXPORT gfloat
 psy_vector4_get_magnitude(PsyVector4 *self);
 
 G_MODULE_EXPORT PsyVector4 *
@@ -32,20 +32,20 @@ G_MODULE_EXPORT gboolean
 psy_vector4_is_null(PsyVector4 *self);
 
 G_MODULE_EXPORT PsyVector4 *
-psy_vector4_add_s(PsyVector4 *self, gdouble scalar);
+psy_vector4_add_s(PsyVector4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector4 *
 psy_vector4_add(PsyVector4 *self, PsyVector4 *other);
 
 G_MODULE_EXPORT PsyVector4 *
-psy_vector4_sub_s(PsyVector4 *self, gdouble scalar);
+psy_vector4_sub_s(PsyVector4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector4 *
 psy_vector4_sub(PsyVector4 *self, PsyVector4 *other);
 
 G_MODULE_EXPORT PsyVector4 *
-psy_vector4_mul_s(PsyVector4 *self, gdouble scalar);
+psy_vector4_mul_s(PsyVector4 *self, gfloat scalar);
 G_MODULE_EXPORT PsyVector4 *
 psy_vector4_mul(PsyVector4 *self, PsyVector4 *other);
-G_MODULE_EXPORT gdouble
+G_MODULE_EXPORT gfloat
 psy_vector4_dot(PsyVector4 *self, PsyVector4 *other);
 
 G_MODULE_EXPORT gboolean
@@ -53,7 +53,7 @@ psy_vector4_equals(PsyVector4 *self, PsyVector4 *other);
 G_MODULE_EXPORT gboolean
 psy_vector4_not_equals(PsyVector4 *self, PsyVector4 *other);
 
-G_MODULE_EXPORT G_MODULE_EXPORT const gdouble *
+G_MODULE_EXPORT G_MODULE_EXPORT const gfloat *
 psy_vector4_ptr(PsyVector4 *self);
 
 G_MODULE_EXPORT GArray *

--- a/psy/psy-window.c
+++ b/psy/psy-window.c
@@ -416,14 +416,12 @@ create_projection_matrix(PsyWindow *self)
             "width_mm", &w_mm,
             "height_mm", &h_mm,
             NULL);
-    // clang-format onn
+    // clang-format on
 
-    width = (gfloat)w;
-    height= (gfloat)h;
-    width_mm = (gfloat) w_mm;
+    width     = (gfloat) w;
+    height    = (gfloat) h;
+    width_mm  = (gfloat) w_mm;
     height_mm = (gfloat) h_mm;
-    bottom    = height;
-    top       = 0.0;
 
     gint style = psy_window_get_projection_style(self);
 

--- a/psy/uniform-color.vert
+++ b/psy/uniform-color.vert
@@ -2,12 +2,12 @@
 
 layout (location = 0) in vec3 aPos; // the position variable has attribute position 0
 
-uniform dmat4 projection;
-uniform dmat4 model;
+uniform mat4 projection;
+uniform mat4 model;
   
 void main()
 {
     // see how we directly give a vec3 to vec4's constructor
     vec4 vertex = vec4(aPos, 1.0); 
-    gl_Position = vec4(projection * model * dvec4(vertex));
+    gl_Position = projection * model * vertex;
 }

--- a/tests/vector3-test.c
+++ b/tests/vector3-test.c
@@ -13,8 +13,8 @@ test_create(void)
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
     psy_vector3_destroy(vec);
 
-    gdouble data[3] = {1, 2, 3};
-    gdouble x, y, z;
+    gfloat data[3] = {1, 2, 3};
+    gfloat x, y, z;
     vec = psy_vector3_new_data(3, data);
     g_object_get(vec, "x", &x, "y", &y, "z", &z, NULL);
     CU_ASSERT_EQUAL(x, data[0]);
@@ -27,13 +27,13 @@ test_create(void)
 static void
 test_magnitude(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     values[3] = {x, y, z};
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      values[3] = {x, y, z};
     PsyVector3 *vec       = psy_vector3_new_data(3, values);
 
-    gdouble length, magnitude;
-    gdouble expected = sqrt(x * x + y * y + z * z);
-    magnitude        = psy_vector3_get_magnitude(vec);
+    gfloat length, magnitude;
+    gfloat expected = sqrt(x * x + y * y + z * z);
+    magnitude       = psy_vector3_get_magnitude(vec);
     g_object_get(vec, "magnitude", &length, NULL);
     CU_ASSERT_EQUAL(magnitude, expected);
     CU_ASSERT_EQUAL(length, magnitude);
@@ -44,8 +44,8 @@ test_magnitude(void)
 static void
 test_unit(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     length;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      length;
     PsyVector3 *vec
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
     PsyVector3 *unit = NULL;
@@ -66,8 +66,8 @@ test_unit(void)
 static void
 test_negate(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     mx, my, mz;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      mx, my, mz;
     PsyVector3 *vec
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
 
@@ -89,9 +89,9 @@ test_negate(void)
 static void
 test_add_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     scalar = 2;
-    gdouble     rx, ry, rz;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      scalar = 2;
+    gfloat      rx, ry, rz;
     PsyVector3 *vec
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
 
@@ -108,7 +108,7 @@ test_add_scalar(void)
 static void
 test_add_vector(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
+    gfloat      x = 10, y = 20, z = 40;
     PsyVector3 *v1
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
     PsyVector3 *v2
@@ -126,9 +126,9 @@ test_add_vector(void)
 static void
 test_sub_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     scalar = 2;
-    gdouble     rx, ry, rz;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      scalar = 2;
+    gfloat      rx, ry, rz;
     PsyVector3 *vec
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
     PsyVector3 *result = psy_vector3_sub_s(vec, scalar);
@@ -144,7 +144,7 @@ test_sub_scalar(void)
 static void
 test_sub_vector(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
+    gfloat      x = 10, y = 20, z = 40;
     PsyVector3 *v1
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
     PsyVector3 *result = psy_vector3_sub(v1, v1);
@@ -157,8 +157,8 @@ test_sub_vector(void)
 static void
 test_mul_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     scalar = 2.0;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      scalar = 2.0;
     PsyVector3 *v1
         = g_object_new(PSY_TYPE_VECTOR3, "x", x, "y", y, "z", z, NULL);
     PsyVector3 *result = psy_vector3_mul_s(v1, scalar);
@@ -181,11 +181,11 @@ test_mul_scalar(void)
 static void
 test_vector_dot(void)
 {
-    gdouble     x = 1, y = 1;
+    gfloat      x = 1, y = 1;
     PsyVector3 *v1, *v2;
-    v1          = g_object_new(PSY_TYPE_VECTOR3, "x", x, NULL);
-    v2          = g_object_new(PSY_TYPE_VECTOR3, "y", y, NULL);
-    gdouble cos = psy_vector3_dot(v1, v2);
+    v1         = g_object_new(PSY_TYPE_VECTOR3, "x", x, NULL);
+    v2         = g_object_new(PSY_TYPE_VECTOR3, "y", y, NULL);
+    gfloat cos = psy_vector3_dot(v1, v2);
     CU_ASSERT_EQUAL(cos, 0.0f);
 
     cos = psy_vector3_dot(v2, v1);

--- a/tests/vector4-test.c
+++ b/tests/vector4-test.c
@@ -14,8 +14,8 @@ test_create(void)
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
     psy_vector4_destroy(vec);
 
-    gdouble data[4] = {1, 2, 3, 4};
-    gdouble x, y, z, w;
+    gfloat data[4] = {1, 2, 3, 4};
+    gfloat x, y, z, w;
     vec = psy_vector4_new_data(4, data);
     g_object_get(vec, "x", &x, "y", &y, "z", &z, "w", &w, NULL);
     CU_ASSERT_EQUAL(x, data[0]);
@@ -29,13 +29,13 @@ test_create(void)
 static void
 test_magnitude(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = 20;
-    gdouble     values[4] = {x, y, z, w};
+    gfloat      x = 10, y = 20, z = 40, w = 20;
+    gfloat      values[4] = {x, y, z, w};
     PsyVector4 *vec       = psy_vector4_new_data(4, values);
 
-    gdouble length, magnitude;
-    gdouble expected = sqrt(x * x + y * y + z * z + w * w);
-    magnitude        = psy_vector4_get_magnitude(vec);
+    gfloat length, magnitude;
+    gfloat expected = sqrt(x * x + y * y + z * z + w * w);
+    magnitude       = psy_vector4_get_magnitude(vec);
     g_object_get(vec, "magnitude", &length, NULL);
     CU_ASSERT_EQUAL(magnitude, expected);
     CU_ASSERT_EQUAL(length, magnitude);
@@ -46,8 +46,8 @@ test_magnitude(void)
 static void
 test_unit(void)
 {
-    gdouble     x = 10, y = 20, z = 40;
-    gdouble     length;
+    gfloat      x = 10, y = 20, z = 40;
+    gfloat      length;
     PsyVector4 *vec
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, NULL);
     PsyVector4 *unit = NULL;
@@ -68,8 +68,8 @@ test_unit(void)
 static void
 test_negate(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = 1;
-    gdouble     mx, my, mz, mw;
+    gfloat      x = 10, y = 20, z = 40, w = 1;
+    gfloat      mx, my, mz, mw;
     PsyVector4 *vec
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
 
@@ -91,9 +91,9 @@ test_negate(void)
 static void
 test_add_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = -50;
-    gdouble     scalar = 2;
-    gdouble     rx, ry, rz, rw;
+    gfloat      x = 10, y = 20, z = 40, w = -50;
+    gfloat      scalar = 2;
+    gfloat      rx, ry, rz, rw;
     PsyVector4 *vec
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
 
@@ -111,7 +111,7 @@ test_add_scalar(void)
 static void
 test_add_vector(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = -50;
+    gfloat      x = 10, y = 20, z = 40, w = -50;
     PsyVector4 *v1
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
     PsyVector4 *v2
@@ -129,9 +129,9 @@ test_add_vector(void)
 static void
 test_sub_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = -50;
-    gdouble     scalar = 2;
-    gdouble     rx, ry, rz, rw;
+    gfloat      x = 10, y = 20, z = 40, w = -50;
+    gfloat      scalar = 2;
+    gfloat      rx, ry, rz, rw;
     PsyVector4 *vec
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
     PsyVector4 *result = psy_vector4_sub_s(vec, scalar);
@@ -148,7 +148,7 @@ test_sub_scalar(void)
 static void
 test_sub_vector(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = -40;
+    gfloat      x = 10, y = 20, z = 40, w = -40;
     PsyVector4 *v1
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
     PsyVector4 *result = psy_vector4_sub(v1, v1);
@@ -161,8 +161,8 @@ test_sub_vector(void)
 static void
 test_mul_scalar(void)
 {
-    gdouble     x = 10, y = 20, z = 40, w = -50;
-    gdouble     scalar = 2.0;
+    gfloat      x = 10, y = 20, z = 40, w = -50;
+    gfloat      scalar = 2.0;
     PsyVector4 *v1
         = g_object_new(PSY_TYPE_VECTOR4, "x", x, "y", y, "z", z, "w", w, NULL);
     PsyVector4 *result = psy_vector4_mul_s(v1, scalar);
@@ -186,11 +186,11 @@ test_mul_scalar(void)
 static void
 test_vector_dot(void)
 {
-    gdouble     x = 1, y = 1;
+    gfloat      x = 1, y = 1;
     PsyVector4 *v1, *v2;
-    v1          = g_object_new(PSY_TYPE_VECTOR4, "x", x, NULL);
-    v2          = g_object_new(PSY_TYPE_VECTOR4, "y", y, NULL);
-    gdouble cos = psy_vector4_dot(v1, v2);
+    v1         = g_object_new(PSY_TYPE_VECTOR4, "x", x, NULL);
+    v2         = g_object_new(PSY_TYPE_VECTOR4, "y", y, NULL);
+    gfloat cos = psy_vector4_dot(v1, v2);
     CU_ASSERT_EQUAL(cos, 0.0f);
 
     cos = psy_vector4_dot(v2, v1);


### PR DESCRIPTION
PsyVector(3/4) and Matrix4 now use floats everywhere. Uses of these variable have been checked, so that no doubles are passed by pointer etc.

fixes #34 