### PR TITLE
Fix/artist creation

### DIFF
--- a/psy/psy-artist.h
+++ b/psy/psy-artist.h
@@ -10,6 +10,12 @@
 
 G_BEGIN_DECLS
 
+// forward declarations
+struct _PsyVisualStimulus;
+typedef struct _PsyVisualStimulus PsyVisualStimulus;
+struct _PsyCanvas;
+typedef struct _PsyCanvas PsyCanvas;
+
 #define PSY_TYPE_ARTIST psy_artist_get_type()
 G_DECLARE_DERIVABLE_TYPE(PsyArtist, psy_artist, PSY, ARTIST, GObject)
 

--- a/psy/psy-canvas.c
+++ b/psy/psy-canvas.c
@@ -237,41 +237,10 @@ set_frame_dur(PsyCanvas *self, PsyDuration *dur)
     priv->frame_dur = psy_duration_dup(dur);
 }
 
-static PsyArtist *
-create_artist(PsyCanvas *self, PsyVisualStimulus *stimulus)
-{
-    GType      type   = G_OBJECT_TYPE(stimulus);
-    PsyArtist *artist = NULL;
-
-    if (type == psy_circle_get_type()) {
-        g_debug("creating circle artist");
-        artist = PSY_ARTIST(psy_circle_artist_new(self, stimulus));
-    }
-    else if (type == psy_cross_get_type()) {
-        g_debug("creating cross artist");
-        artist = PSY_ARTIST(psy_cross_artist_new(self, stimulus));
-    }
-    else if (type == psy_rectangle_get_type()) {
-        g_debug("creating rectangle artist");
-        artist = PSY_ARTIST(psy_rectangle_artist_new(self, stimulus));
-    }
-    else if (type == psy_picture_get_type()) {
-        g_debug("creating picture artist");
-        artist = PSY_ARTIST(psy_picture_artist_new(self, stimulus));
-    }
-    else {
-        g_warning("PsyCanvas hasn't got an Artist for %s",
-                  G_OBJECT_TYPE_NAME(stimulus));
-    }
-
-    return artist;
-}
-
 static void
 schedule_stimulus(PsyCanvas *self, PsyVisualStimulus *stimulus)
 {
     PsyCanvasPrivate *priv = psy_canvas_get_instance_private(self);
-    PsyCanvasClass   *cls  = PSY_CANVAS_GET_CLASS(self);
 
     // Check if the stimulus is already scheduled
     if (g_hash_table_contains(priv->artists, stimulus)) {
@@ -279,7 +248,7 @@ schedule_stimulus(PsyCanvas *self, PsyVisualStimulus *stimulus)
         return;
     }
 
-    PsyArtist *artist = cls->create_artist(self, stimulus);
+    PsyArtist *artist = psy_visual_stimulus_create_artist(stimulus);
 
     // add a reference for insertion in array and hashtable
     g_object_ref(stimulus);
@@ -544,7 +513,6 @@ psy_canvas_class_init(PsyCanvasClass *klass)
 
     klass->set_frame_dur = set_frame_dur;
 
-    klass->create_artist     = create_artist;
     klass->schedule_stimulus = schedule_stimulus;
     klass->remove_stimulus   = remove_stimulus;
 

--- a/psy/psy-canvas.h
+++ b/psy/psy-canvas.h
@@ -73,7 +73,6 @@ typedef struct _PsyCanvasClass {
     PsyDuration *(*get_frame_dur)(PsyCanvas *self);
     void (*set_frame_dur)(PsyCanvas *self, PsyDuration *dur);
 
-    PsyArtist *(*create_artist)(PsyCanvas *self, PsyVisualStimulus *stimulus);
     void (*schedule_stimulus)(PsyCanvas *self, PsyVisualStimulus *stimulus);
     void (*remove_stimulus)(PsyCanvas *self, PsyVisualStimulus *stimulus);
 

--- a/psy/psy-circle.c
+++ b/psy/psy-circle.c
@@ -1,5 +1,6 @@
 
 #include "psy-circle.h"
+#include "psy-circle-artist.h"
 
 /**
  * PsyCircle:
@@ -75,12 +76,22 @@ psy_circle_init(PsyCircle *self)
     priv->radius           = 1;
 }
 
+static PsyArtist *
+circle_create_artist(PsyVisualStimulus *self)
+{
+    return PSY_ARTIST(
+        psy_circle_artist_new(psy_visual_stimulus_get_canvas(self), self));
+}
+
 static void
 psy_circle_class_init(PsyCircleClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = circle_get_property;
     object_class->set_property = circle_set_property;
+
+    PsyVisualStimulusClass *vstim_cls = PSY_VISUAL_STIMULUS_CLASS(klass);
+    vstim_cls->create_artist          = circle_create_artist;
 
     /**
      * Circle:radius:

--- a/psy/psy-cross.c
+++ b/psy/psy-cross.c
@@ -1,6 +1,6 @@
 
 #include "psy-cross.h"
-#include "glibconfig.h"
+#include "psy-cross-artist.h"
 
 typedef struct _PsyCrossPrivate {
     gfloat x_length;
@@ -91,12 +91,22 @@ psy_cross_init(PsyCross *self)
     (void) self;
 }
 
+static PsyArtist *
+cross_create_artist(PsyVisualStimulus *self)
+{
+    return PSY_ARTIST(
+        psy_cross_artist_new(psy_visual_stimulus_get_canvas(self), self));
+}
+
 static void
 psy_cross_class_init(PsyCrossClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = cross_get_property;
     object_class->set_property = cross_set_property;
+
+    PsyVisualStimulusClass *vstim_cls = PSY_VISUAL_STIMULUS_CLASS(klass);
+    vstim_cls->create_artist          = cross_create_artist;
 
     /**
      * Cross:line-length:

--- a/psy/psy-picture.c
+++ b/psy/psy-picture.c
@@ -1,6 +1,7 @@
 
 #include "psy-picture.h"
 #include "enum-types.h"
+#include "psy-picture-artist.h"
 
 /**
  * PsyPicture:
@@ -121,6 +122,13 @@ auto_resize(PsyPicture *picture, gfloat width, gfloat height)
     psy_rectangle_set_size(PSY_RECTANGLE(picture), width, height);
 }
 
+static PsyArtist *
+picture_create_artist(PsyVisualStimulus *self)
+{
+    return PSY_ARTIST(
+        psy_picture_artist_new(psy_visual_stimulus_get_canvas(self), self));
+}
+
 static void
 psy_picture_class_init(PsyPictureClass *klass)
 {
@@ -128,6 +136,9 @@ psy_picture_class_init(PsyPictureClass *klass)
     object_class->get_property = picture_get_property;
     object_class->set_property = picture_set_property;
     object_class->finalize     = psy_picture_finalize;
+
+    PsyVisualStimulusClass *vstim_class = PSY_VISUAL_STIMULUS_CLASS(klass);
+    vstim_class->create_artist          = picture_create_artist;
 
     PsyRectangleClass *rect_class = PSY_RECTANGLE_CLASS(klass);
     rect_class->set_width         = set_width;

--- a/psy/psy-rectangle.c
+++ b/psy/psy-rectangle.c
@@ -1,6 +1,6 @@
 
 #include "psy-rectangle.h"
-#include "glibconfig.h"
+#include "psy-rectangle-artist.h"
 
 typedef struct _PsyRectanglePrivate {
     gfloat width;
@@ -84,12 +84,22 @@ set_height(PsyRectangle *self, gfloat height)
     priv->height = height;
 }
 
+static PsyArtist *
+rectangle_create_artist(PsyVisualStimulus *self)
+{
+    return PSY_ARTIST(
+        psy_rectangle_artist_new(psy_visual_stimulus_get_canvas(self), self));
+}
+
 static void
 psy_rectangle_class_init(PsyRectangleClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->get_property = rectangle_get_property;
     object_class->set_property = rectangle_set_property;
+
+    PsyVisualStimulusClass *vstim_cls = PSY_VISUAL_STIMULUS_CLASS(klass);
+    vstim_cls->create_artist          = rectangle_create_artist;
 
     klass->set_width  = set_width;
     klass->set_height = set_height;

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -915,6 +915,31 @@ psy_visual_stimulus_set_color(PsyVisualStimulus *self, PsyColor *color)
     priv->color = psy_color_dup(color);
 }
 
+/**
+ * psy_visual_stimulus_create_artist:
+ * @self: an instance of [class@VisualStimulus]
+ *
+ * This method creates a new visual stimulus for this specific stimulus. The
+ * artist should be able to draw this stimulus. It is intended to be called by
+ * an instance of [class@PsyCanvas] when this stimulus is scheduled. The
+ * created artist is responsible to draw this stimulus on the canvas.
+ * Deriving classes must override the [method@Psy.VisualStimulus.create_artist].
+ *
+ * Returns:(transfer full): An instance of [class@Psy.Artist] that will be used
+ * to draw this stimulus
+ */
+PsyArtist *
+psy_visual_stimulus_create_artist(PsyVisualStimulus *self)
+{
+    g_return_val_if_fail(PSY_IS_VISUAL_STIMULUS(self), NULL);
+
+    PsyVisualStimulusClass *cls = PSY_VISUAL_STIMULUS_GET_CLASS(self);
+
+    g_return_val_if_fail(cls->create_artist, NULL);
+
+    return cls->create_artist(self);
+}
+
 /* ************ utility functions for unit conversions ************** */
 
 /**

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -5,6 +5,30 @@
 #include "psy-stimulus.h"
 #include "psy-visual-stimulus.h"
 
+/**
+ * PsyVisualStimulus:
+ *
+ * This is the base class for visual stimuli. A PsyVisualStimulus is a stimulus
+ * that is going to be presented at an instance of [class@PsyCanvas]. The
+ * Base class sets up the frame work for when a stimulus is presented and
+ * also where. Additionally it supports, some scaling and rotation of a
+ * stimulus. This contains all the parameters to setup a Model matrix for this
+ * stimulus. A visual stimulus also supports a color, so that artist know
+ * in what color stimuli should be presented.
+ *
+ * Instances of [class@VisualStimulus] are scheduled when the stimulus is
+ * played. When, the stimulus is scheduled, the canvas will call the
+ * [method@Psy.VisualStimulus.create_artist], which should instantiate the
+ * artist. The artist will be responsible for drawing the stimulus. The
+ * PsyVisualStimulus is merely a dataholder.
+ *
+ * Derived instances may use the framework setup by [class@VisualStimulus]
+ * and [class@Artist] to do drawing. The base class PsyVisualStimulus and
+ * PsyArtist work together, so that deriving class can draw around the origin,
+ * PsyVisualStimulus and PsyArtist make sure that the stimuli are positioned
+ * on the right place.
+ */
+
 typedef struct PsyVisualStimulusPrivate {
     PsyCanvas *canvas; // The canvas on which this stimulus should be presented
 

--- a/psy/psy-visual-stimulus.h
+++ b/psy/psy-visual-stimulus.h
@@ -24,7 +24,9 @@ G_DECLARE_DERIVABLE_TYPE(
 /**
  * PsyVisualStimulusClass:
  * @parent: the parentclass of PsyVisualStimulus it derives form PsyStimulus.
- * @update: signal emitted just prior to the object should be painted again
+ * @update: signal emitted just prior to the object should be painted again.
+ * @create_artist: Pure virtual method, deriving classes should implement this
+ *                 It is called by a canvas when the stimulus is scheduled.
  */
 typedef struct _PsyVisualStimulusClass {
     PsyStimulusClass parent;

--- a/psy/psy-visual-stimulus.h
+++ b/psy/psy-visual-stimulus.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "psy-artist.h"
 #include "psy-canvas.h"
 #include "psy-color.h"
 #include "psy-stimulus.h"
@@ -13,6 +14,8 @@ G_BEGIN_DECLS
  */
 struct _PsyCanvas;
 typedef struct _PsyCanvas PsyCanvas;
+struct _PsyArtist;
+typedef struct _PsyArtist PsyArtist;
 
 #define PSY_TYPE_VISUAL_STIMULUS psy_visual_stimulus_get_type()
 G_DECLARE_DERIVABLE_TYPE(
@@ -28,6 +31,8 @@ typedef struct _PsyVisualStimulusClass {
     void (*update)(PsyVisualStimulus *stim,
                    PsyTimePoint      *frame_time,
                    gint64             nth_frame);
+    PsyArtist *(*create_artist)(PsyVisualStimulus *self);
+
 } PsyVisualStimulusClass;
 
 G_MODULE_EXPORT PsyCanvas *
@@ -96,6 +101,9 @@ G_MODULE_EXPORT PsyColor *
 psy_visual_stimulus_get_color(PsyVisualStimulus *self);
 G_MODULE_EXPORT void
 psy_visual_stimulus_set_color(PsyVisualStimulus *self, PsyColor *color);
+
+G_MODULE_EXPORT PsyArtist *
+psy_visual_stimulus_create_artist(PsyVisualStimulus *self);
 
 /* utility functions to convert degrees to radians and vice versa */
 


### PR DESCRIPTION
Previously, A PsyCanvas created an artist when a stimulus was scheduled. This didn't work well for client that derived from an PsyVisualStimulus. The canvas wouldn't know the class, and didn't know to instantiate the proper artist. This situation is resolved by this merge request. Currently, a canvas calls psy_visual_stimulus_create_artist() on the stimulus, a virtual method that must be implemented by classes deriving from PsyVisualStimulus. That method makes sure that the right artist type is used to create a new Artist e.g. a PsyCircleArtist for a PsyCircle etc.
This resolves issue #38 