### PR TITLE
Fix/naming issues

### DIFF
--- a/psy/backend_gtk/psy-gtk-window.c
+++ b/psy/backend_gtk/psy-gtk-window.c
@@ -597,7 +597,9 @@ psy_gtk_window_class_init(PsyGtkWindowClass *klass)
  * psy_gtk_window_new:(constructor):
  *
  * Returns a new #PsyGtkWindow instance on the first monitor.
- * @return
+ *
+ * Returns: a newly initialized window it may be freed with psy_gtk_window_free
+ * or g_object_unref
  */
 PsyGtkWindow *
 psy_gtk_window_new(void)
@@ -616,7 +618,8 @@ psy_gtk_window_new(void)
  * by @n. If a number larger than n is chosen it will appear on n minus one
  * where n is the number of connected monitors.
  *
- * Returns: a newly initialized window
+ * Returns: a newly initialized window it may be freed with psy_gtk_window_free
+ * or g_object_unref
  */
 PsyGtkWindow *
 psy_gtk_window_new_for_monitor(gint n)
@@ -667,4 +670,16 @@ psy_gtk_window_compute_frame_stats(PsyGtkWindow *self, PsyTimePoint *tp_new)
     else {
         self->frames_lapsed = 1;
     }
+}
+
+/**
+ * psy_gtk_window_free:(skip)
+ *
+ * Destroys a psy window created with psy_gtk_window*new family of functions
+ */
+void
+psy_gtk_window_free(PsyGtkWindow *self)
+{
+    g_return_if_fail(PSY_IS_GTK_WINDOW(self));
+    g_object_unref(self);
 }

--- a/psy/backend_gtk/psy-gtk-window.h
+++ b/psy/backend_gtk/psy-gtk-window.h
@@ -15,6 +15,9 @@ psy_gtk_window_new(void);
 G_MODULE_EXPORT PsyGtkWindow *
 psy_gtk_window_new_for_monitor(gint monitor);
 
+G_MODULE_EXPORT void
+psy_gtk_window_free(PsyGtkWindow *self);
+
 G_END_DECLS
 
 #endif

--- a/psy/gl/psy-gl-canvas.c
+++ b/psy/gl/psy-gl-canvas.c
@@ -560,7 +560,7 @@ psy_gl_canvas_class_init(PsyGlCanvasClass *klass)
  * @width: The desired width of the context
  * @height: The desired height of the context
  *
- * Returns: a new PsyGlCanvas.
+ * Returns: a new PsyGlCanvas. free with psy_gl_canvas_free or g_object_unref
  */
 PsyGlCanvas *
 psy_gl_canvas_new(gint width, gint height)
@@ -592,7 +592,7 @@ psy_gl_canvas_new(gint width, gint height)
  * least 3.3 version with @gl_major and @gl_minor, for OpenGL ES, you should
  * aim for at least 2.0
  *
- * Returns: a new PsyGlCanvas.
+ * Returns: a new PsyGlCanvas. free with psy_gl_canvas_free or g_object_unref
  */
 PsyGlCanvas *
 psy_gl_canvas_new_full(gint     width,
@@ -616,4 +616,14 @@ psy_gl_canvas_new_full(gint     width,
                         NULL
                         );
     // clang-format on
+}
+
+/**
+ * psy_gl_canvas_free:(skip)
+ */
+void
+psy_gl_canvas_free(PsyGlCanvas *self)
+{
+    g_return_if_fail(PSY_IS_GL_CANVAS(self));
+    g_object_unref(self);
 }

--- a/psy/gl/psy-gl-canvas.h
+++ b/psy/gl/psy-gl-canvas.h
@@ -19,4 +19,7 @@ psy_gl_canvas_new_full(gint     width,
                        gint     gl_major,
                        gint     gl_minor);
 
+G_MODULE_EXPORT void
+psy_gl_canvas_free(PsyGlCanvas *self);
+
 G_END_DECLS

--- a/psy/gl/psy-gl-fragment-shader.c
+++ b/psy/gl/psy-gl-fragment-shader.c
@@ -41,9 +41,26 @@ psy_gl_fragment_shader_class_init(PsyGlFragmentShaderClass *klass)
 
 /* ******************** public functions ************************ */
 
+/**
+ * psy_gl_fragment_shader_new:(constructor)
+ *
+ * Returns:
+ */
 PsyGlFragmentShader *
-psy_gl_fragment_shader_new()
+psy_gl_fragment_shader_new(void)
 {
     PsyGlFragmentShader *ret = g_object_new(PSY_TYPE_GL_FRAGMENT_SHADER, NULL);
     return ret;
+}
+
+/**
+ * psy_gl_fragment_shader_free:(skip)
+ *
+ * free a instance previously created with psy_gl_fragment_shader_new()
+ */
+void
+psy_gl_fragment_shader_free(PsyGlFragmentShader *self)
+{
+    g_return_if_fail(PSY_IS_GL_FRAGMENT_SHADER(self));
+    g_object_unref(self);
 }

--- a/psy/gl/psy-gl-fragment-shader.h
+++ b/psy/gl/psy-gl-fragment-shader.h
@@ -14,7 +14,10 @@ G_DECLARE_FINAL_TYPE(PsyGlFragmentShader,
                      PsyGlShader)
 
 G_MODULE_EXPORT PsyGlFragmentShader *
-psy_gl_fragment_shader_new();
+psy_gl_fragment_shader_new(void);
+
+G_MODULE_EXPORT void
+psy_gl_fragment_shader_free(PsyGlFragmentShader *self);
 
 G_END_DECLS
 

--- a/psy/gl/psy-gl-program.c
+++ b/psy/gl/psy-gl-program.c
@@ -415,11 +415,29 @@ psy_gl_program_class_init(PsyGlProgramClass *class)
 
 /* ************ public functions ******************** */
 
+/**
+ * psy_gl_program_new:(constructor)
+ *
+ * Construct a new PsyGlProgram.
+ *
+ * Returns: A freshly created PsyGlProgram, this object may be freed with
+ * psy_gl_program_free or g_object_unref.
+ */
 PsyGlProgram *
-psy_gl_program_new()
+psy_gl_program_new(void)
 {
     PsyGlProgram *gl_program = g_object_new(PSY_TYPE_GL_PROGRAM, NULL);
     return gl_program;
+}
+
+/**
+ * psy_gl_program_free:(skip)
+ */
+void
+psy_gl_program_free(PsyGlProgram *self)
+{
+    g_return_if_fail(PSY_IS_GL_PROGRAM(self));
+    g_object_unref(self);
 }
 
 guint

--- a/psy/gl/psy-gl-program.h
+++ b/psy/gl/psy-gl-program.h
@@ -9,7 +9,10 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(PsyGlProgram, psy_gl_program, PSY, GL_PROGRAM, PsyProgram)
 
 G_MODULE_EXPORT PsyGlProgram *
-psy_gl_program_new();
+psy_gl_program_new(void);
+
+G_MODULE_EXPORT void
+psy_gl_program_free(PsyGlProgram *self);
 
 G_MODULE_EXPORT guint
 psy_gl_program_get_object_id(PsyGlProgram *program);

--- a/psy/gl/psy-gl-texture.c
+++ b/psy/gl/psy-gl-texture.c
@@ -352,24 +352,76 @@ psy_gl_texture_class_init(PsyGlTextureClass *class)
 
 /* ************ public functions ******************** */
 
+/**
+ * psy_gl_texture_new:(constructor)
+ *
+ * Frees PsyGlTextures previously created with psy_gl_texture_new*() familiy
+ * of functions.
+ *
+ * Returns: A new PsyGlTexture to be freed with g_object_unref of
+ * psy_gl_texture_free
+ */
 PsyGlTexture *
 psy_gl_texture_new(void)
 {
     return g_object_new(PSY_TYPE_GL_TEXTURE, NULL);
 }
 
+/**
+ * psy_gl_texture_new_for_file:(constructor)
+ *
+ * Create a new PsyGlTexture with the [property@Texture:file] specified
+ * So that the texture knows about which file we are talking.
+ *
+ * Frees PsyGlTextures previously created with psy_gl_texture_new*() familiy
+ * of function.
+ *
+ * Returns: A new PsyGlTexture to be freed with g_object_unref of
+ * psy_gl_texture_free.
+ */
 PsyGlTexture *
 psy_gl_texture_new_for_file(GFile *file)
 {
     return g_object_new(PSY_TYPE_GL_TEXTURE, "file", file, NULL);
 }
 
+/**
+ * psy_gl_texture_new_for_path:(constructor)
+ *
+ * Create a new PsyGlTexture with the [property@Texture:path] specified
+ * So that the texture knows about which file we are talking.
+ *
+ * Returns: A new PsyGlTexture to be freed with g_object_unref or
+ * psy_gl_texture_free.
+ */
 PsyGlTexture *
 psy_gl_texture_new_for_path(const gchar *path)
 {
     return g_object_new(PSY_TYPE_GL_TEXTURE, "path", path, NULL);
 }
 
+/**
+ * psy_gl_texture_free:(skip)
+ *
+ * Frees PsyGlTextures previously created with psy_gl_texture_new*() familiy
+ * of functions.
+ */
+void
+psy_gl_texture_free(PsyGlTexture *self)
+{
+    g_return_if_fail(PSY_IS_GL_TEXTURE(self));
+    g_object_unref(self);
+}
+
+/**
+ * psy_gl_texture_get_object_id:
+ *
+ * OpenGL stores textures with an id, returned from glGenTextures. When
+ * the texture exists, you'll typically first need to bind it before using it.
+ * glBindTexture
+ *
+ * Returns: An integer that identifies this texture for opengl
+ */
 guint
 psy_gl_texture_get_object_id(PsyGlTexture *self)
 {

--- a/psy/gl/psy-gl-texture.h
+++ b/psy/gl/psy-gl-texture.h
@@ -24,6 +24,9 @@ psy_gl_texture_new_for_file(GFile *file);
 G_MODULE_EXPORT PsyGlTexture *
 psy_gl_texture_new_for_path(const gchar *path);
 
+G_MODULE_EXPORT void
+psy_gl_texture_free(PsyGlTexture *self);
+
 G_MODULE_EXPORT guint
 psy_gl_texture_get_object_id(PsyGlTexture *self);
 

--- a/psy/gl/psy-gl-vbuffer.c
+++ b/psy/gl/psy-gl-vbuffer.c
@@ -261,11 +261,31 @@ psy_gl_vbuffer_class_init(PsyGlVBufferClass *class)
 
 /* ************ public functions ******************** */
 
+/**
+ * psy_gl_vbuffer_new:(constructor)
+ *
+ * Create a new PsyGlVBuffer object.
+ *
+ * Returns: A new instance of [class@PsyGlVBuffer] that should be freed
+ * with g_object_unref or psy_gl_vbuffer_free.
+ */
 PsyGlVBuffer *
 psy_gl_vbuffer_new(void)
 {
     PsyGlVBuffer *gl_vbuffer = g_object_new(PSY_TYPE_GL_VBUFFER, NULL);
     return gl_vbuffer;
+}
+
+/**
+ * psy_gl_vbuffer_free:(skip)
+ *
+ * Free a PsyGlVBuffer object. Previously created with psy_gl_vbuffer_new.
+ */
+void
+psy_gl_vbuffer_free(PsyGlVBuffer *self)
+{
+    g_return_if_fail(PSY_IS_GL_VBUFFER(self));
+    g_object_unref(self);
 }
 
 guint

--- a/psy/gl/psy-gl-vbuffer.h
+++ b/psy/gl/psy-gl-vbuffer.h
@@ -9,7 +9,10 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(PsyGlVBuffer, psy_gl_vbuffer, PSY, GL_VBUFFER, PsyVBuffer)
 
 G_MODULE_EXPORT PsyGlVBuffer *
-psy_gl_vbuffer_new();
+psy_gl_vbuffer_new(void);
+
+G_MODULE_EXPORT void
+psy_gl_vbuffer_free(PsyGlVBuffer *self);
 
 G_MODULE_EXPORT guint
 psy_gl_vbuffer_get_object_id(PsyGlVBuffer *vbuffer);

--- a/psy/gl/psy-gl-vertex-shader.c
+++ b/psy/gl/psy-gl-vertex-shader.c
@@ -10,7 +10,7 @@ typedef struct _PsyGlVertexShader {
 G_DEFINE_TYPE(PsyGlVertexShader, psy_gl_vertex_shader, PSY_TYPE_GL_SHADER)
 
 static GLuint
-psy_gl_vertex_shader_create_shader()
+psy_gl_vertex_shader_create_shader(void)
 {
     GLuint object_id;
     object_id = glCreateShader(GL_VERTEX_SHADER);
@@ -41,9 +41,29 @@ psy_gl_vertex_shader_class_init(PsyGlVertexShaderClass *klass)
 
 /* ************ public functions *************/
 
+/**
+ * psy_gl_vertext_shader_new:(constructor)
+ *
+ * Creates a new vertex shader for OpenGL
+ *
+ * Returns: a new VertexShader for OpenGL, to be freed with
+ * psy_gl_vertext_shader_free
+ */
 PsyGlVertexShader *
-psy_gl_vertex_shader_new()
+psy_gl_vertex_shader_new(void)
 {
     PsyGlVertexShader *shader = g_object_new(PSY_TYPE_GL_VERTEX_SHADER, NULL);
     return shader;
+}
+
+/**
+ * psy_gl_vertext_shader_free:(skip)
+ *
+ * frees vertex shader created with psy_gl_vertext_shader new before
+ */
+void
+psy_gl_vertext_shader_free(PsyGlVertexShader *self)
+{
+    g_return_if_fail(PSY_IS_GL_VERTEX_SHADER(self));
+    g_object_unref(self);
 }

--- a/psy/gl/psy-gl-vertex-shader.h
+++ b/psy/gl/psy-gl-vertex-shader.h
@@ -11,7 +11,10 @@ G_DECLARE_FINAL_TYPE(
     PsyGlVertexShader, psy_gl_vertex_shader, PSY, GL_VERTEX_SHADER, PsyGlShader)
 
 G_MODULE_EXPORT PsyGlVertexShader *
-psy_gl_vertex_shader_new();
+psy_gl_vertex_shader_new(void);
+
+G_MODULE_EXPORT void
+psy_gl_vertex_shader_free(void);
 
 G_END_DECLS
 

--- a/psy/hw/psy-parallel-port.c
+++ b/psy/hw/psy-parallel-port.c
@@ -318,6 +318,18 @@ psy_parallel_port_new(void)
 }
 
 /**
+ * psy_parallel_port_free:(skip)
+ *
+ * Frees instance created with [ctor@ParallelPort.new]
+ */
+void
+psy_parallel_port_free(PsyParallelPort *self)
+{
+    g_return_if_fail(PSY_IS_PARALLEL_PORT(self));
+    g_object_unref(self);
+}
+
+/**
  * psy_parallel_port_open:
  * @self: an instance of PsyParallelPort
  * @dev_num: The nth device to open.

--- a/psy/hw/psy-parallel-port.h
+++ b/psy/hw/psy-parallel-port.h
@@ -102,6 +102,9 @@ G_MODULE_EXPORT PsyParallelPort *
 psy_parallel_port_new(void);
 
 G_MODULE_EXPORT void
+psy_parallel_port_free(PsyParallelPort *self);
+
+G_MODULE_EXPORT void
 psy_parallel_port_open(PsyParallelPort *self, gint dev_num, GError **error);
 
 G_MODULE_EXPORT void

--- a/psy/hw/psy-parport.c
+++ b/psy/hw/psy-parport.c
@@ -13,7 +13,9 @@
  * PsyParport:
  *
  * PsyParport is a final class for parallel ports on Linux. It derives from
- * PsyParallePort and implements it.
+ * PsyParallelPort and implements it. Typically you can instantiate instances
+ * of this class with [ctor@ParallelPort.new] and that constructor
+ * determines the right backend for your system.
  */
 
 typedef struct _PsyParport {

--- a/psy/hw/psy-parport.h
+++ b/psy/hw/psy-parport.h
@@ -9,7 +9,4 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE(PsyParport, psy_parport, PSY, PARPORT, PsyParallelPort)
 
-G_MODULE_EXPORT PsyParport *
-psy_parport_new(void);
-
 G_END_DECLS

--- a/psy/jack/psy-jack-audio-device.c
+++ b/psy/jack/psy-jack-audio-device.c
@@ -463,8 +463,20 @@ psy_jack_audio_device_class_init(PsyJackAudioDeviceClass *klass)
  *
  * Returns: a instance of [class@PsyJackAudioDevice]
  */
-PsyAudioDevice *
+PsyJackAudioDevice *
 psy_jack_audio_device_new(void)
 {
     return g_object_new(PSY_TYPE_JACK_AUDIO_DEVICE, NULL);
+}
+
+/**
+ * psy_jack_audio_device_free:(skip)
+ *
+ * Frees instances created with psy_jack_audio_device_new
+ */
+void
+psy_jack_audio_device_free(PsyJackAudioDevice *self)
+{
+    g_return_if_fail(PSY_IS_JACK_AUDIO_DEVICE(self));
+    g_object_unref(self);
 }

--- a/psy/jack/psy-jack-audio-device.h
+++ b/psy/jack/psy-jack-audio-device.h
@@ -12,8 +12,11 @@ G_DECLARE_FINAL_TYPE(PsyJackAudioDevice,
                      JACK_AUDIO_DEVICE,
                      PsyAudioDevice)
 
-PsyAudioDevice *
+G_MODULE_EXPORT PsyJackAudioDevice *
 psy_jack_audio_device_new(void);
+
+G_MODULE_EXPORT void
+psy_jack_audio_device_free(PsyJackAudioDevice *self);
 
 G_END_DECLS
 

--- a/psy/portaudio/psy-pa-device.c
+++ b/psy/portaudio/psy-pa-device.c
@@ -815,14 +815,26 @@ psy_pa_device_class_init(PsyPADeviceClass *klass)
 /**
  * psy_pa_device_new:(constructor)
  *
- * Constructs an jack audio device.
- * This object will try to connect to or instantiate a jack server in order
- * to obtain the playback and capture devices.
+ * Constructs an Portaudio audio device. This object uses portaudio in order
+ * to comunnicate with the audio devices.
  *
- * Returns: a instance of [class@PsyPADevice]
+ * Returns: a instance of [class@PsyPADevice] free with g_object_unref of
+ * psy_pa_device_free
  */
-PsyAudioDevice *
+PsyPADevice *
 psy_pa_device_new(void)
 {
     return g_object_new(PSY_TYPE_PA_DEVICE, NULL);
+}
+
+/**
+ * psy_pa_device_free:(skip)
+ *
+ * Frees instances of [class@PADevice]
+ */
+void
+psy_pa_device_free(PsyPADevice *self)
+{
+    g_return_if_fail(PSY_IS_PA_DEVICE(self));
+    g_object_unref(self);
 }

--- a/psy/portaudio/psy-pa-device.h
+++ b/psy/portaudio/psy-pa-device.h
@@ -8,8 +8,11 @@ G_BEGIN_DECLS
 #define PSY_TYPE_PA_DEVICE psy_pa_device_get_type()
 G_DECLARE_FINAL_TYPE(PsyPADevice, psy_pa_device, PSY, PA_DEVICE, PsyAudioDevice)
 
-PsyAudioDevice *
+G_MODULE_EXPORT PsyPADevice *
 psy_pa_device_new(void);
+
+G_MODULE_EXPORT void
+psy_pa_device_free(PsyPADevice *self);
 
 G_END_DECLS
 

--- a/psy/psy-audio-channel-map.c
+++ b/psy/psy-audio-channel-map.c
@@ -6,12 +6,12 @@
 
 G_DEFINE_BOXED_TYPE(PsyAudioChannelMapping,
                     psy_audio_channel_mapping,
-                    psy_audio_channel_mapping_dup,
+                    psy_audio_channel_mapping_copy,
                     psy_audio_channel_mapping_free)
 
 G_DEFINE_BOXED_TYPE(PsyAudioChannelMap,
                     psy_audio_channel_map,
-                    psy_audio_channel_map_dup,
+                    psy_audio_channel_map_copy,
                     psy_audio_channel_map_free)
 
 #pragma GCC diagnostic pop
@@ -52,7 +52,7 @@ psy_audio_channel_mapping_free(PsyAudioChannelMapping *self)
 }
 
 /**
- * psy_audio_channel_mapping_dup:
+ * psy_audio_channel_mapping_copy:
  * @self: an instance of [struct@PsyAudioChannelMapping]
  *
  * Create a deep copy of a mapping
@@ -60,7 +60,7 @@ psy_audio_channel_mapping_free(PsyAudioChannelMapping *self)
  * Returns:(transfer full): a new instance of [struct@PsyAudioChannelMapping]
  */
 PsyAudioChannelMapping *
-psy_audio_channel_mapping_dup(PsyAudioChannelMapping *self)
+psy_audio_channel_mapping_copy(PsyAudioChannelMapping *self)
 {
     g_return_val_if_fail(self != NULL, FALSE);
 
@@ -195,11 +195,11 @@ copy_mapping(gconstpointer src, gpointer data)
 {
     (void) data;
     PsyAudioChannelMapping *original = (PsyAudioChannelMapping *) src;
-    return psy_audio_channel_mapping_dup(original);
+    return psy_audio_channel_mapping_copy(original);
 }
 
 /**
- * psy_audio_channel_map_dup:
+ * psy_audio_channel_map_copy:
  * @self: the instance of [struct@AudioChannelMap] to copy
  *
  * Makes a deep copy of @self.
@@ -207,7 +207,7 @@ copy_mapping(gconstpointer src, gpointer data)
  * Returns: A deep copy of self.
  */
 PsyAudioChannelMap *
-psy_audio_channel_map_dup(PsyAudioChannelMap *self)
+psy_audio_channel_map_copy(PsyAudioChannelMap *self)
 {
     PsyAudioChannelMap *new = g_malloc(sizeof(PsyAudioChannelMap));
 
@@ -331,7 +331,7 @@ psy_audio_channel_map_get_mapping(PsyAudioChannelMap *self, guint index)
 
     PsyAudioChannelMapping *original = self->mapping->pdata[index];
 
-    return psy_audio_channel_mapping_dup(original);
+    return psy_audio_channel_mapping_copy(original);
 }
 
 /**
@@ -355,7 +355,7 @@ psy_audio_channel_map_add(PsyAudioChannelMap     *self,
     g_return_val_if_fail(
         mapping->mapped_source < (gint) self->num_source_channels, FALSE);
 
-    g_ptr_array_add(self->mapping, psy_audio_channel_mapping_dup(mapping));
+    g_ptr_array_add(self->mapping, psy_audio_channel_mapping_copy(mapping));
 
     return TRUE;
 }
@@ -391,6 +391,6 @@ psy_audio_channel_map_set(PsyAudioChannelMap     *self,
                          FALSE);
 
     psy_audio_channel_mapping_free(self->mapping->pdata[index]);
-    self->mapping->pdata[index] = psy_audio_channel_mapping_dup(mapping);
+    self->mapping->pdata[index] = psy_audio_channel_mapping_copy(mapping);
     return TRUE;
 }

--- a/psy/psy-audio-channel-map.h
+++ b/psy/psy-audio-channel-map.h
@@ -36,7 +36,7 @@ G_MODULE_EXPORT void
 psy_audio_channel_mapping_free(PsyAudioChannelMapping *self);
 
 G_MODULE_EXPORT PsyAudioChannelMapping *
-psy_audio_channel_mapping_dup(PsyAudioChannelMapping *self);
+psy_audio_channel_mapping_copy(PsyAudioChannelMapping *self);
 
 G_MODULE_EXPORT gboolean
 psy_audio_channel_mapping_eq(PsyAudioChannelMapping *self,
@@ -72,7 +72,7 @@ G_MODULE_EXPORT GType
 psy_audio_channel_map_get_type(void);
 
 G_MODULE_EXPORT PsyAudioChannelMap *
-psy_audio_channel_map_dup(PsyAudioChannelMap *self);
+psy_audio_channel_map_copy(PsyAudioChannelMap *self);
 
 G_MODULE_EXPORT void
 psy_audio_channel_map_free(PsyAudioChannelMap *self);

--- a/psy/psy-audio-device.c
+++ b/psy/psy-audio-device.c
@@ -620,18 +620,18 @@ psy_audio_device_class_init(PsyAudioDeviceClass *klass)
  *
  * Constructs an audio device. This constructor will check which backends
  * are available on this machine and if so, it will try to get the best one
- * possible.
- * The returned device will implement a PsyAudioDevice for one specific
- * backend.
+ * possible. The returned device will implement a PsyAudioDevice for one
+ * specific backend.
  *
  * Returns: A platform specific instance of [class@PsyAudioDevice] that will
- *          implement this class.
+ *          implement this class. Free with psy_audio_device_free or
+ *          g_object_unref
  */
 PsyAudioDevice *
 psy_audio_device_new(void)
 {
 #if defined HAVE_PORTAUDIO
-    return psy_pa_device_new();
+    return PSY_AUDIO_DEVICE(psy_pa_device_new());
 #elif defined HAVE_ALSA
     return psy_alsa_audio_device_new();
 #elif defined HAVE_JACK2
@@ -639,6 +639,18 @@ psy_audio_device_new(void)
 #else
     return NULL;
 #endif
+}
+
+/**
+ * psy_audio_device_free:(skip)
+ *
+ * frees instance previously created with [ctor@AudioDevice.new]
+ */
+void
+psy_audio_device_free(PsyAudioDevice *self)
+{
+    g_return_if_fail(PSY_IS_AUDIO_DEVICE(self));
+    g_object_unref(self);
 }
 
 gboolean

--- a/psy/psy-audio-device.h
+++ b/psy/psy-audio-device.h
@@ -145,6 +145,9 @@ G_MODULE_EXPORT PsyAudioDevice *
 psy_audio_device_new(void);
 
 G_MODULE_EXPORT void
+psy_audio_device_free(PsyAudioDevice *self);
+
+G_MODULE_EXPORT void
 psy_audio_device_open(PsyAudioDevice *self, GError **error);
 
 G_MODULE_EXPORT void

--- a/psy/psy-audio-mixer.c
+++ b/psy/psy-audio-mixer.c
@@ -520,6 +520,19 @@ psy_audio_mixer_new(PsyAudioDevice *device, PsyDuration *buf_dur)
 }
 
 /**
+ * psy_audio_buffer_free:(skip)
+ *
+ * Frees instances of [class@AudioMixer] previously created with
+ * [ctor@AudioMixer.new] or g_object_new.
+ */
+void
+psy_audio_mixer_free(PsyAudioMixer *self)
+{
+    g_return_if_fail(PSY_IS_AUDIO_MIXER(self));
+    g_object_unref(self);
+}
+
+/**
  * psy_audio_mixer_get_buffer_duration:
  * @self: an instance of[class@AudioMixer]
  *

--- a/psy/psy-audio-mixer.h
+++ b/psy/psy-audio-mixer.h
@@ -49,6 +49,9 @@ typedef struct _PsyAudioMixerClass {
 G_MODULE_EXPORT PsyAudioMixer *
 psy_audio_mixer_new(PsyAudioDevice *device, PsyDuration *buf_dur);
 
+G_MODULE_EXPORT void
+psy_audio_mixer_free(PsyAudioMixer *self);
+
 G_MODULE_EXPORT PsyDuration *
 psy_audio_mixer_get_buffer_duration(PsyAudioMixer *self);
 

--- a/psy/psy-auditory-stimulus.c
+++ b/psy/psy-auditory-stimulus.c
@@ -581,7 +581,7 @@ psy_auditory_stimulus_get_channel_map(PsyAuditoryStimulus *self)
     if (priv->channel_map == NULL)
         return NULL;
 
-    return psy_audio_channel_map_dup(priv->channel_map);
+    return psy_audio_channel_map_copy(priv->channel_map);
 }
 
 /**
@@ -602,7 +602,7 @@ psy_auditory_stimulus_set_channel_map(PsyAuditoryStimulus *self,
     g_return_if_fail(map != NULL);
 
     g_clear_pointer(&priv->channel_map, psy_audio_channel_map_free);
-    priv->channel_map = psy_audio_channel_map_dup(map);
+    priv->channel_map = psy_audio_channel_map_copy(map);
 }
 
 /**

--- a/psy/psy-canvas.c
+++ b/psy/psy-canvas.c
@@ -843,7 +843,7 @@ psy_canvas_set_background_color(PsyCanvas *self, PsyColor *color)
     PsyCanvasPrivate *priv = psy_canvas_get_instance_private(self);
 
     g_clear_object(&priv->background_color);
-    priv->background_color = psy_color_dup(color);
+    priv->background_color = psy_color_copy(color);
 }
 
 /**

--- a/psy/psy-circle-artist.c
+++ b/psy/psy-circle-artist.c
@@ -157,3 +157,10 @@ psy_circle_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
 
     return circle_artist;
 }
+
+void
+psy_circle_artist_free(PsyCircleArtist *self)
+{
+    g_return_if_fail(PSY_IS_CIRCLE_ARTIST(self));
+    g_object_unref(self);
+}

--- a/psy/psy-circle-artist.h
+++ b/psy/psy-circle-artist.h
@@ -14,6 +14,9 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyCircleArtist *
 psy_circle_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus);
 
+G_MODULE_EXPORT void
+psy_circle_artist_free(PsyCircleArtist *self);
+
 G_MODULE_EXPORT guint
 psy_circle_artist_get_object_id(PsyCircleArtist *circle);
 

--- a/psy/psy-circle.c
+++ b/psy/psy-circle.c
@@ -136,7 +136,7 @@ psy_circle_class_init(PsyCircleClass *klass)
  * psy_circle_new:(constructor)
  * @canvas: an instance of [class@Canvas] on which this stimulus should be drawn
  *
- * Returns: a new instance of `PsyCircle` with default values.
+ * Returns: a new instance of [class@Circle] with default values.
  */
 PsyCircle *
 psy_circle_new(PsyCanvas *canvas)
@@ -159,7 +159,7 @@ psy_circle_new(PsyCanvas *canvas)
  * vertices required depends a little on the radius of the triangle, the
  * larger the circle, the larger the number of vertices is required.
  *
- * Returns: a new instance of `PsyCircle` with the provided values.
+ * Returns: a new instance of [class@Circle] with the provided values.
  */
 PsyCircle *
 psy_circle_new_full(
@@ -176,6 +176,13 @@ psy_circle_new_full(
             NULL);
     // clang-format on
 }
+
+/**
+ * psy_circle_free: (skip)
+ *
+ * Frees Circles previously allocated with the psy_circle_new_* family
+ * of constructors.
+ */
 
 /**
  * psy_circle_set_radius:

--- a/psy/psy-circle.h
+++ b/psy/psy-circle.h
@@ -20,6 +20,9 @@ psy_circle_new_full(
     PsyCanvas *canvas, gfloat x, gfloat y, gfloat radius, guint num_vertices);
 
 G_MODULE_EXPORT void
+psy_circle_free(PsyCircle *self);
+
+G_MODULE_EXPORT void
 psy_circle_set_radius(PsyCircle *circle, gfloat radius);
 
 G_MODULE_EXPORT gfloat

--- a/psy/psy-clock.c
+++ b/psy/psy-clock.c
@@ -107,7 +107,7 @@ psy_clock_class_init(PsyClockClass *klass)
  *
  * Creates a clock for retrieving the current time.
  *
- * Returns: A new `PsyClock` instance.
+ * Returns: A new [class@Clock] instance.
  */
 PsyClock *
 psy_clock_new(void)
@@ -117,11 +117,23 @@ psy_clock_new(void)
 }
 
 /**
+ * psy_clock_free:(skip)
+ *
+ * Free instances of [class@Clock].
+ */
+void
+psy_clock_free(PsyClock *self)
+{
+    g_return_if_fail(PSY_IS_CLOCK(self));
+    g_object_unref(self);
+}
+
+/**
  * psy_clock_now:
  * @self: An instance of a `PsyClock`
  *
  * This is the way to obtain the current time in a psylib program.
- * The time starts running at 0 when the first instance of [class@clock]
+ * The time starts running at 0 when the first instance of [class@Clock]
  * is instantiated. This function returns the current time.
  *
  * Returns:(transfer full): A [struct@TimePoint] instance representing the

--- a/psy/psy-clock.h
+++ b/psy/psy-clock.h
@@ -11,6 +11,9 @@ G_DECLARE_FINAL_TYPE(PsyClock, psy_clock, PSY, CLOCK, GObject)
 G_MODULE_EXPORT PsyClock *
 psy_clock_new(void);
 
+G_MODULE_EXPORT void
+psy_clock_free(PsyClock *self);
+
 G_MODULE_EXPORT PsyTimePoint *
 psy_clock_now(PsyClock *self);
 

--- a/psy/psy-color.c
+++ b/psy/psy-color.c
@@ -400,7 +400,20 @@ psy_color_new_rgbai(gint r, gint g, gint b, gint a)
 }
 
 /**
- * psy_color_dup:
+ * psy_color_free:(skip)
+ *
+ * frees instances of [class@Color] previously allocated with the
+ * psy_color_new* family of Color constructors
+ */
+void
+psy_color_free(PsyColor *self)
+{
+    g_return_if_fail(PSY_IS_COLOR(self));
+    g_object_unref(self);
+}
+
+/**
+ * psy_color_copy:
  * @self: a color to duplicate
  *
  * This duplicates an existing color.
@@ -408,7 +421,7 @@ psy_color_new_rgbai(gint r, gint g, gint b, gint a)
  * Returns:(transfer full): A copy of the input.
  */
 PsyColor *
-psy_color_dup(PsyColor *self)
+psy_color_copy(PsyColor *self)
 {
     g_return_val_if_fail(PSY_IS_COLOR(self), NULL);
     // clang-format off

--- a/psy/psy-color.h
+++ b/psy/psy-color.h
@@ -14,7 +14,7 @@ G_BEGIN_DECLS
  */
 #define PSY_TYPE_RGB (psy_rgba_get_type())
 G_MODULE_EXPORT GType
-psy_rgba_get_type();
+psy_rgba_get_type(void);
 
 typedef struct _PsyRgba PsyRgba;
 
@@ -65,8 +65,11 @@ psy_color_new_rgbi(gint r, gint g, gint b);
 G_MODULE_EXPORT PsyColor *
 psy_color_new_rgbai(gint r, gint g, gint b, gint a);
 
+G_MODULE_EXPORT void
+psy_color_free(PsyColor *self);
+
 G_MODULE_EXPORT PsyColor *
-psy_color_dup(PsyColor *self);
+psy_color_copy(PsyColor *self);
 
 G_MODULE_EXPORT gfloat
 psy_color_get_red(PsyColor *self);

--- a/psy/psy-cross-artist.c
+++ b/psy/psy-cross-artist.c
@@ -120,41 +120,41 @@ cross_artist_draw(PsyArtist *self)
         gfloat x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12;
         gfloat y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12;
 
-        x1 = artist->ywidth / 2.0;
-        y1 = artist->ylength / 2.0;
+        x1 = artist->ywidth / 2.0f;
+        y1 = artist->ylength / 2.0f;
 
-        x2 = artist->ywidth / 2.0;
-        y2 = artist->xwidth / 2.0;
+        x2 = artist->ywidth / 2.0f;
+        y2 = artist->xwidth / 2.0f;
 
-        x3 = artist->xlength / 2.0;
-        y3 = artist->xwidth / 2.0;
+        x3 = artist->xlength / 2.0f;
+        y3 = artist->xwidth / 2.0f;
 
-        x4 = artist->xlength / 2.0;
-        y4 = -artist->xwidth / 2.0;
+        x4 = artist->xlength / 2.0f;
+        y4 = -artist->xwidth / 2.0f;
 
-        x5 = artist->ywidth / 2.0;
-        y5 = -artist->xwidth / 2.0;
+        x5 = artist->ywidth / 2.0f;
+        y5 = -artist->xwidth / 2.0f;
 
-        x6 = artist->ywidth / 2.0;
-        y6 = -artist->xlength / 2.0;
+        x6 = artist->ywidth / 2.0f;
+        y6 = -artist->xlength / 2.0f;
 
-        x7 = -artist->ywidth / 2.0;
-        y7 = -artist->xlength / 2.0;
+        x7 = -artist->ywidth / 2.0f;
+        y7 = -artist->xlength / 2.0f;
 
-        x8 = -artist->ywidth / 2.0;
-        y8 = -artist->xwidth / 2.0;
+        x8 = -artist->ywidth / 2.0f;
+        y8 = -artist->xwidth / 2.0f;
 
-        x9 = -artist->xlength / 2.0;
-        y9 = -artist->xwidth / 2.0;
+        x9 = -artist->xlength / 2.0f;
+        y9 = -artist->xwidth / 2.0f;
 
-        x10 = -artist->xlength / 2.0;
-        y10 = artist->xwidth / 2.0;
+        x10 = -artist->xlength / 2.0f;
+        y10 = artist->xwidth / 2.0f;
 
-        x11 = -artist->ywidth / 2.0;
-        y11 = artist->xwidth / 2.0;
+        x11 = -artist->ywidth / 2.0f;
+        y11 = artist->xwidth / 2.0f;
 
-        x12 = -artist->ywidth / 2.0;
-        y12 = artist->ylength / 2.0;
+        x12 = -artist->ywidth / 2.0f;
+        y12 = artist->ylength / 2.0f;
 
         psy_vbuffer_set_xyz(artist->vertices, 1, x1, y1, 0);
         psy_vbuffer_set_xyz(artist->vertices, 2, x2, y2, 0);
@@ -202,6 +202,16 @@ psy_cross_artist_class_init(PsyCrossArtistClass *class)
 
 /* ************ public functions ******************** */
 
+/**
+ * psy_cross_artist_new:(constructor)
+ * @canvas: The instance of[class@Canvas] to draw on
+ * @stimulus: The cross stimulus that should be drawn
+ *
+ * Creates a new Cross artist that is able to paint a cross on the canvas
+ *
+ * Returns: A new artist that should be freed with g_object_unref or
+ * psy_cross_artist_free
+ */
 PsyCrossArtist *
 psy_cross_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
 {
@@ -212,4 +222,17 @@ psy_cross_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
         PSY_TYPE_CROSS_ARTIST, "canvas", canvas, "stimulus", stimulus, NULL);
 
     return cross_artist;
+}
+
+/**
+ * psy_cross_artist_free:(skip)
+ *
+ * Frees instances of [class@PsyCrossArtist] previously allocated with
+ * psy_cross_artist_new
+ */
+void
+psy_cross_artist_free(PsyCrossArtist *self)
+{
+    g_return_if_fail(PSY_IS_CROSS_ARTIST(self));
+    g_object_unref(self);
 }

--- a/psy/psy-cross-artist.h
+++ b/psy/psy-cross-artist.h
@@ -14,6 +14,9 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyCrossArtist *
 psy_cross_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus);
 
+G_MODULE_EXPORT void
+psy_cross_artist_free(PsyCrossArtist *self);
+
 G_MODULE_EXPORT guint
 psy_cross_artist_get_object_id(PsyCrossArtist *cross);
 

--- a/psy/psy-cross.c
+++ b/psy/psy-cross.c
@@ -207,6 +207,9 @@ psy_cross_class_init(PsyCrossClass *klass)
  * @canvas: an instance of [class@PsyCanvas] on which this stimulus should be
  * drawn.
  *
+ * Instances of PsyCross may be freed with g_object_unref and
+ * [method@Cross.free]
+ *
  * Returns: a new instance of [class@PsyCross] with default values.
  */
 PsyCross *
@@ -222,6 +225,9 @@ psy_cross_new(PsyCanvas *canvas)
  * @y: The y coordinate for the cross
  * @length: The length of the cross lines
  * @line_width: The width of the line
+ *
+ * Instances of PsyCross may be freed with g_object_unref and
+ * [method@Cross.free]
  *
  * Returns: a new instance of [class@PsyCross] with the provided values.
  */
@@ -239,6 +245,18 @@ psy_cross_new_full(
             "line-width", line_width,
             NULL);
     // clang-format on
+}
+
+/**
+ * psy_cross_free:skip
+ *
+ * Frees instances previously created with psy_cross_new* family of functions
+ */
+void
+psy_cross_free(PsyCross *self)
+{
+    g_return_if_fail(PSY_IS_CROSS(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-cross.h
+++ b/psy/psy-cross.h
@@ -20,6 +20,9 @@ psy_cross_new_full(
     PsyCanvas *canvas, gfloat x, gfloat y, gfloat length, gfloat line_width);
 
 G_MODULE_EXPORT void
+psy_cross_free(PsyCross *self);
+
+G_MODULE_EXPORT void
 psy_cross_set_line_length_x(PsyCross *cross, gfloat length);
 
 G_MODULE_EXPORT gfloat

--- a/psy/psy-duration.c
+++ b/psy/psy-duration.c
@@ -128,6 +128,7 @@ psy_duration_new_s(gint64 s)
 void
 psy_duration_free(PsyDuration *self)
 {
+    g_return_if_fail(self != NULL);
     g_free(self);
 }
 

--- a/psy/psy-image-canvas.c
+++ b/psy/psy-image-canvas.c
@@ -174,15 +174,31 @@ psy_image_canvas_class_init(PsyImageCanvasClass *klass)
  * Creates a possibly platform specific [class@PsyImageCanvas] instance.
  * Currently it will in practice return an instance of [class@PsyGlCanvas]
  * which is a derived instance of PsyImageCanvas. That supports the same
- * methods. If in the future an instance of PsyD3dCanvas is retured on
+ * methods. If in the future an instance of PsyD3dCanvas is returned on
  * windows for example is yet to be determined.
  *
- * Returns: an instance of [class@ImageCanvas].
+ * Returns: an instance of [class@ImageCanvas]. This instance may be freed
+ * with g_object_unref or psy_image_canvas_free
  */
 PsyImageCanvas *
 psy_image_canvas_new(gint width, gint height)
 {
+    g_return_val_if_fail(width > 0, NULL);
+    g_return_val_if_fail(height > 0, NULL);
+
     return PSY_IMAGE_CANVAS(psy_gl_canvas_new(width, height));
+}
+
+/**
+ * psy_image_canvas_free:(skip)
+ *
+ * Free canvases previously created with psy_image_canvas_new
+ */
+void
+psy_image_canvas_free(PsyImageCanvas *self)
+{
+    g_return_if_fail(PSY_IS_IMAGE_CANVAS(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-image-canvas.h
+++ b/psy/psy-image-canvas.h
@@ -28,6 +28,12 @@ typedef struct _PsyImageCanvasClass {
     gpointer padding[12];
 } PsyImageCanvasClass;
 
+G_MODULE_EXPORT PsyImageCanvas *
+psy_image_canvas_new(gint width, gint height);
+
+G_MODULE_EXPORT void
+psy_image_canvas_free(PsyImageCanvas *self);
+
 G_MODULE_EXPORT void
 psy_image_canvas_iterate(PsyImageCanvas *self);
 
@@ -36,8 +42,5 @@ psy_image_canvas_set_time(PsyImageCanvas *self, PsyTimePoint *tp);
 
 G_MODULE_EXPORT PsyTimePoint *
 psy_image_canvas_get_time(PsyImageCanvas *self);
-
-G_MODULE_EXPORT PsyImageCanvas *
-psy_image_canvas_new(gint width, gint height);
 
 G_END_DECLS

--- a/psy/psy-image.c
+++ b/psy/psy-image.c
@@ -251,7 +251,8 @@ psy_image_class_init(PsyImageClass *klass)
  * Create a new instance of PsyImage, with the specified dimensions in
  * pixels. For the num_channels see [method@Psy.Image.set_num_channels]
  *
- * Returns: a new instance of PsyImage.
+ * Returns: a new instance of [class@Image], these instances may be freed
+ * with g_object_unref or [method@Image.free]
  */
 PsyImage *
 psy_image_new(guint width, guint height, PsyImageFormat format)
@@ -263,6 +264,18 @@ psy_image_new(guint width, guint height, PsyImageFormat format)
                         "format", format,
                         NULL);
     // clang-format on
+}
+
+/**
+ * psy_image_free:(skip)
+ *
+ * Frees images previously allocated with [ctor@Image.new]
+ */
+void
+psy_image_free(PsyImage *self)
+{
+    g_return_if_fail(PSY_IS_IMAGE(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-image.h
+++ b/psy/psy-image.h
@@ -14,6 +14,9 @@ G_MODULE_EXPORT PsyImage *
 psy_image_new(guint width, guint height, PsyImageFormat format);
 
 G_MODULE_EXPORT void
+psy_image_free(PsyImage *self);
+
+G_MODULE_EXPORT void
 psy_image_set_width(PsyImage *self, guint width);
 
 G_MODULE_EXPORT guint

--- a/psy/psy-loop.c
+++ b/psy/psy-loop.c
@@ -289,11 +289,11 @@ psy_loop_new_full(gint64           index,
 }
 
 /**
- * psy_loop_destroy:
+ * psy_loop_free:
  * @self:The loop to destroy
  */
 void
-psy_loop_destroy(PsyLoop *loop)
+psy_loop_free(PsyLoop *loop)
 {
     g_return_if_fail(PSY_IS_LOOP(loop));
     g_object_unref(loop);

--- a/psy/psy-loop.c
+++ b/psy/psy-loop.c
@@ -257,10 +257,12 @@ psy_loop_init(PsyLoop *self)
  * psy_loop_new:(constructor)
  *
  * Returns a new loop.
- * Returns:a new loop with its default - not so useful - parameters.
+ *
+ * Returns: a new loop with its default - not so useful - parameters. The
+ *          instance may be freed with g_object_unref or psy_loop_free
  */
 PsyLoop *
-psy_loop_new()
+psy_loop_new(void)
 {
     return g_object_new(PSY_TYPE_LOOP, NULL);
 }
@@ -269,7 +271,9 @@ psy_loop_new()
  * psy_loop_new_full:(constructor):
  *
  * Creates a new loop with all parameters specified.
+ *
  * Returns: A new loop with all parameters specified.
+ *          May be freed with g_object_unref or psy_loop_free
  */
 PsyLoop *
 psy_loop_new_full(gint64           index,

--- a/psy/psy-loop.h
+++ b/psy/psy-loop.h
@@ -30,7 +30,7 @@ psy_loop_new_full(gint64           index,
                   PsyLoopCondition condition);
 
 G_MODULE_EXPORT void
-psy_loop_destroy(PsyLoop *self);
+psy_loop_free(PsyLoop *self);
 
 G_MODULE_EXPORT void
 psy_loop_iterate(PsyLoop *self, PsyTimePoint *timestamp);

--- a/psy/psy-matrix4.cpp
+++ b/psy/psy-matrix4.cpp
@@ -225,7 +225,7 @@ psy_matrix4_new_perspective(gfloat fovy,
 /**
  * psy_matrix4_free:
  *
- * Destroys a `PsyMatrix4` instance
+ * Destroys a [class@Matrix4] instance
  *
  * self: the matrix to destroy
  */

--- a/psy/psy-matrix4.cpp
+++ b/psy/psy-matrix4.cpp
@@ -223,14 +223,14 @@ psy_matrix4_new_perspective(gfloat fovy,
 }
 
 /**
- * psy_matrix4_destroy:
+ * psy_matrix4_free:
  *
  * Destroys a `PsyMatrix4` instance
  *
  * self: the matrix to destroy
  */
 void
-psy_matrix4_destroy(PsyMatrix4 *self)
+psy_matrix4_free(PsyMatrix4 *self)
 {
     g_object_unref(self);
 }

--- a/psy/psy-matrix4.h
+++ b/psy/psy-matrix4.h
@@ -34,7 +34,7 @@ psy_matrix4_new_perspective(gfloat fovy,
                             gfloat far);
 
 G_MODULE_EXPORT void
-psy_matrix4_destroy(PsyMatrix4 *v);
+psy_matrix4_free(PsyMatrix4 *v);
 
 G_MODULE_EXPORT void
 psy_matrix4_set_identity(PsyMatrix4 *self);

--- a/psy/psy-picture-artist.c
+++ b/psy/psy-picture-artist.c
@@ -214,6 +214,9 @@ psy_picture_artist_class_init(PsyPictureArtistClass *class)
  * @stimulus: An instance of [class@Picture], which this artist will be drawing
  *
  * Create a new [class@PsyPictureArtist] that is going to draw @stimulus.
+ *
+ * Returns: A new instance to be freed with g_object_unref
+ *          or[method@PictureArtist.free]
  */
 PsyPictureArtist *
 psy_picture_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
@@ -231,4 +234,16 @@ psy_picture_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
     // clang-format on
 
     return picture_artist;
+}
+
+/**
+ * psy_picture_artist_free:(skip)
+ *
+ * Frees a PictureArtist previously allocated with [ctor@PictureArtist.new]
+ */
+void
+psy_picuture_artist_free(PsyPictureArtist *self)
+{
+    g_return_if_fail(PSY_IS_PICTURE_ARTIST(self));
+    g_object_unref(self);
 }

--- a/psy/psy-picture-artist.h
+++ b/psy/psy-picture-artist.h
@@ -13,6 +13,9 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyPictureArtist *
 psy_picture_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus);
 
+G_MODULE_EXPORT void
+psy_picture_artist_free(PsyPictureArtist *self);
+
 G_END_DECLS
 
 #endif

--- a/psy/psy-picture.c
+++ b/psy/psy-picture.c
@@ -14,6 +14,9 @@
  * to use a method like [method@Psy.DrawingContext.load_files_as_texture] in
  * advance. This will load, decode and turn a file into a texture. Then drawing
  * is very fast.
+ *
+ * Instances of PsyPicture may be freed with [method@Picture.free] or
+ * g_object_unref
  */
 
 typedef struct _PsyPicturePrivate {
@@ -298,6 +301,19 @@ psy_picture_new_full(PsyCanvas   *canvas,
             "filename", filename,
             NULL);
     // clang-format on
+}
+
+/**
+ * psy_picture_free:(skip)
+ *
+ * frees pictures previously created with the psy_picture_new* family of
+ * constructors.
+ */
+void
+psy_picture_free(PsyPicture *self)
+{
+    g_return_if_fail(PSY_IS_PICTURE(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-picture.h
+++ b/psy/psy-picture.h
@@ -35,6 +35,9 @@ psy_picture_new_full(PsyCanvas   *canvas,
                      const gchar *filename);
 
 G_MODULE_EXPORT void
+psy_picture_free(PsyPicture *self);
+
+G_MODULE_EXPORT void
 psy_picture_set_filename(PsyPicture *self, const gchar *filename);
 
 G_MODULE_EXPORT const gchar *

--- a/psy/psy-rectangle-artist.c
+++ b/psy/psy-rectangle-artist.c
@@ -163,3 +163,15 @@ psy_rectangle_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
 
     return rectangle_artist;
 }
+
+/**
+ * psy_rectangle_artist_free:(skip)
+ *
+ * Frees instances of [class@RectangleArtist]
+ */
+void
+psy_rectangle_artist_free(PsyRectangleArtist *self)
+{
+    g_return_if_fail(PSY_IS_RECTANGLE_ARTIST(self));
+    g_object_unref(self);
+}

--- a/psy/psy-rectangle-artist.h
+++ b/psy/psy-rectangle-artist.h
@@ -14,6 +14,9 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyRectangleArtist *
 psy_rectangle_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus);
 
+G_MODULE_EXPORT void
+psy_rectangle_artist_free(PsyRectangleArtist *self);
+
 G_MODULE_EXPORT guint
 psy_rectangle_artist_get_object_id(PsyRectangleArtist *rectangle);
 

--- a/psy/psy-rectangle.c
+++ b/psy/psy-rectangle.c
@@ -161,6 +161,7 @@ psy_rectangle_new(PsyCanvas *canvas)
  * @height: the height of the rectangle along(x-axis)
  *
  * Returns: a new instance of [class@Rectangle] with the provided values.
+ *          The rectangle may be freed with g_object_unref or psy_rectangle_free
  */
 PsyRectangle *
 psy_rectangle_new_full(
@@ -176,6 +177,18 @@ psy_rectangle_new_full(
             "height", height,
             NULL);
     // clang-format on
+}
+
+/**
+ * psy_rectangle_free:(skip)
+ *
+ * frees rectangle that are created with psy_rectangle_new* family of functions
+ */
+void
+psy_rectangle_free(PsyRectangle *self)
+{
+    g_return_if_fail(PSY_IS_RECTANGLE(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-rectangle.h
+++ b/psy/psy-rectangle.h
@@ -35,6 +35,9 @@ psy_rectangle_new_full(
     PsyCanvas *canvas, gfloat x, gfloat y, gfloat width, gfloat height);
 
 G_MODULE_EXPORT void
+psy_rectangle_free(PsyRectangle *rect);
+
+G_MODULE_EXPORT void
 psy_rectangle_set_width(PsyRectangle *self, gfloat width);
 
 G_MODULE_EXPORT gfloat

--- a/psy/psy-stepping-stones.c
+++ b/psy/psy-stepping-stones.c
@@ -152,7 +152,6 @@ psy_stepping_stones_class_init(PsySteppingStonesClass *klass)
  * psy_stepping_stones_new:(constructor)
  *
  * Creates a new `PsySteppingStones` object
- * Returns: a new `PsySteppingStones` instance
  *
  * Create a new instance of PsySteppingStones. You can use
  * psy_stepping_stones_free or g_object_unref on the instance in order to free
@@ -172,7 +171,7 @@ psy_stepping_stones_new(void)
  * psy_stepping_stones_free:(skip)
  *
  * Frees an instance of [class@SteppingStones] previously allocated with
- * [constructor@PsySteppingStones.new]
+ * [ctor@PsySteppingStones.new]
  */
 void
 psy_stepping_stones_free(PsySteppingStones *self)

--- a/psy/psy-stepping-stones.c
+++ b/psy/psy-stepping-stones.c
@@ -153,6 +153,14 @@ psy_stepping_stones_class_init(PsySteppingStonesClass *klass)
  *
  * Creates a new `PsySteppingStones` object
  * Returns: a new `PsySteppingStones` instance
+ *
+ * Create a new instance of PsySteppingStones. You can use
+ * psy_stepping_stones_free or g_object_unref on the instance in order to free
+ * it. psy_stepping_stones_free does a type check before calling g_object_unref
+ * on the object, so it is slightly more safe.
+ *
+ * Returns: Instance of [class@SteppingStones], may be freed with
+ * [method@SteppingStones.free]
  */
 PsySteppingStones *
 psy_stepping_stones_new(void)
@@ -160,8 +168,14 @@ psy_stepping_stones_new(void)
     return g_object_new(PSY_TYPE_STEPPING_STONES, NULL);
 }
 
+/**
+ * psy_stepping_stones_free:(skip)
+ *
+ * Frees an instance of [class@SteppingStones] previously allocated with
+ * [constructor@PsySteppingStones.new]
+ */
 void
-psy_stepping_stones_destroy(PsySteppingStones *self)
+psy_stepping_stones_free(PsySteppingStones *self)
 {
     g_return_if_fail(PSY_IS_STEPPING_STONES(self));
     g_object_unref(self);

--- a/psy/psy-stepping-stones.h
+++ b/psy/psy-stepping-stones.h
@@ -26,7 +26,7 @@ G_MODULE_EXPORT PsySteppingStones *
 psy_stepping_stones_new(void);
 
 G_MODULE_EXPORT void
-psy_stepping_stones_destroy(PsySteppingStones *self);
+psy_stepping_stones_free(PsySteppingStones *self);
 
 G_MODULE_EXPORT void
 psy_stepping_stones_add_step(PsySteppingStones *self, PsyStep *step);

--- a/psy/psy-text-artist.c
+++ b/psy/psy-text-artist.c
@@ -196,3 +196,15 @@ psy_text_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus)
 
     return text_artist;
 }
+
+/**
+ * psy_text_artist_free:(skip)
+ *
+ * Frees an text artist
+ */
+void
+psy_text_artist_free(PsyTextArtist *self)
+{
+    g_return_if_fail(PSY_IS_TEXT_ARTIST(self));
+    g_object_unref(self);
+}

--- a/psy/psy-text-artist.h
+++ b/psy/psy-text-artist.h
@@ -13,6 +13,9 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyTextArtist *
 psy_text_artist_new(PsyCanvas *canvas, PsyVisualStimulus *stimulus);
 
+G_MODULE_EXPORT void
+psy_text_artist_free(PsyTextArtist *self);
+
 G_END_DECLS
 
 #endif

--- a/psy/psy-text.c
+++ b/psy/psy-text.c
@@ -269,6 +269,8 @@ psy_text_class_init(PsyTextClass *klass)
  * @canvas: an instance of [class@Canvas] on which this stimulus should be
  * drawn
  *
+ * Returned instances may be destroyed with [method@Text.free] or g_object_unref
+ *
  * Returns: a new instance of [class@PsyText] with default values.
  */
 PsyText *
@@ -294,6 +296,8 @@ psy_text_new(PsyCanvas *canvas)
  * default the [property@Psy.Text:use-markup] is false, so if the content
  * contains markup you should set that property to %TRUE.
  *
+ * Returned instances may be destroyed with [method@Text.free] or g_object_unref
+ *
  * Returns: a new instance of [class@Text] with the provided values.
  */
 PsyText *
@@ -317,6 +321,18 @@ psy_text_new_full(PsyCanvas   *canvas,
             "use-markup", use_markup,
             NULL);
     // clang-format on
+}
+
+/**
+ * psy_text_free:(skip)
+ *
+ * Frees instances of [class@Text]
+ */
+void
+psy_text_free(PsyText *self)
+{
+    g_return_if_fail(PSY_IS_TEXT(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-text.h
+++ b/psy/psy-text.h
@@ -34,6 +34,9 @@ psy_text_new_full(PsyCanvas   *canvas,
                   const gchar *content,
                   gboolean     use_markup);
 
+G_MODULE_EXPORT void
+psy_text_free(PsyText *self);
+
 G_MODULE_EXPORT const gchar *
 psy_text_get_content(PsyText *self);
 

--- a/psy/psy-time-point.c
+++ b/psy/psy-time-point.c
@@ -25,7 +25,7 @@ G_DEFINE_BOXED_TYPE(PsyTimePoint,
  * timepoint with the [struct@TimePoint.new], but than the timepoint isn't
  * really meaning full. It would reflect the timepoint at which the clock
  * would start ticking. You can however, create a timepoint from a result of
- * [method@GLib.get_monotonic_time], these timepoint are then shifted so that
+ * [func@GLib.get_monotonic_time], these timepoint are then shifted so that
  * they are comparable as if they were returned from our own [class@Clock]
  */
 
@@ -36,8 +36,8 @@ G_DEFINE_BOXED_TYPE(PsyTimePoint,
  * You should take care that if no clock has been created. It only makes sense
  * after an instance of [class@Clock] is created.
  *
- * Returns:An instance of [class@TimePoint] that reflects the start of the
- *         experiment.
+ * Returns:An instance of [struct@TimePoint] that reflects the start of the
+ *         experiment. Free the timepoint with [method@TimePoint.free]
  */
 PsyTimePoint *
 psy_time_point_new(void)
@@ -55,7 +55,8 @@ psy_time_point_new(void)
  * can use this function to get a timepoint that is equivalent to psylib's
  * time. The time by psylib starts at 0 when the first clock is Instantiated.
  *
- * Returns: a [struct@imePoint] obtained from the monotonic clock of glib.
+ * Returns: a [struct@TimePoint] obtained from the monotonic clock of glib.
+ *          Free the timepoint with [method@TimePoint.free].
  */
 PsyTimePoint *
 psy_time_point_new_monotonic(gint64 monotonic_time)

--- a/psy/psy-trial.c
+++ b/psy/psy-trial.c
@@ -19,8 +19,28 @@ psy_trial_init(PsyTrial *trial)
     (void) trial;
 }
 
+/**
+ * psy_trial_new:(constructor)
+ *
+ * Create a new trial, to be freed with g_object_unref or [method@Tria.free]
+ *
+ * Returns: a new [class@Trial] instance
+ */
 PsyTrial *
 psy_trial_new(void)
 {
     return g_object_new(PSY_TYPE_TRIAL, NULL);
+}
+
+/**
+ * psy_trial_free:(skip)
+ *
+ *
+ * Frees a trial previoulsy allocated with psy_trial_new* fam of functions
+ */
+void
+psy_trial_free(PsyTrial *self)
+{
+    g_return_if_fail(PSY_IS_TRIAL(self));
+    g_object_unref(self);
 }

--- a/psy/psy-trial.h
+++ b/psy/psy-trial.h
@@ -12,6 +12,9 @@ G_DECLARE_FINAL_TYPE(PsyTrial, psy_trial, PSY, TRIAL, PsyStep)
 G_MODULE_EXPORT PsyTrial *
 psy_trial_new(void);
 
+G_MODULE_EXPORT void
+psy_trial_free(PsyTrial *trial);
+
 G_END_DECLS
 
 #endif

--- a/psy/psy-vector.c
+++ b/psy/psy-vector.c
@@ -126,8 +126,15 @@ psy_vector_class_init(PsyVectorClass *klass)
 
 /* ************* public functions ************* */
 
+/**
+ * psy_vector_new:
+ *
+ * Create a new 3D vector with all elements set to 0.0;
+ *
+ * Returns a new instance of [class@Vector]
+ */
 PsyVector *
-psy_vector_new()
+psy_vector_new(void)
 {
     return psy_vector_new_xyz(0, 0, 0);
 }
@@ -156,6 +163,11 @@ psy_vector_new_xyz(gfloat x, gfloat y, gfloat z)
     return v;
 }
 
+/**
+ * psy_vector_free:(skip)
+ *
+ * Frees instances of [class@Vector]
+ */
 void
 psy_vector_free(PsyVector *self)
 {

--- a/psy/psy-vector.c
+++ b/psy/psy-vector.c
@@ -157,8 +157,9 @@ psy_vector_new_xyz(gfloat x, gfloat y, gfloat z)
 }
 
 void
-psy_vector_destroy(PsyVector *self)
+psy_vector_free(PsyVector *self)
 {
+    g_return_if_fail(PSY_IS_VECTOR(self));
     g_object_unref(self);
 }
 

--- a/psy/psy-vector.h
+++ b/psy/psy-vector.h
@@ -25,7 +25,7 @@ PsyVector *
 psy_vector_new_xyz(gfloat x, gfloat y, gfloat z);
 
 void
-psy_vector_destroy(PsyVector *self);
+psy_vector_free(PsyVector *self);
 
 gfloat
 psy_vector_magnitude(PsyVector *self);

--- a/psy/psy-vector3.cpp
+++ b/psy/psy-vector3.cpp
@@ -215,6 +215,7 @@ psy_vector3_new_data(gsize n, gfloat *values)
 void
 psy_vector3_free(PsyVector3 *self)
 {
+    g_return_if_fail(PSY_IS_VECTOR3(self));
     g_object_unref(self);
 }
 

--- a/psy/psy-vector3.cpp
+++ b/psy/psy-vector3.cpp
@@ -209,11 +209,11 @@ psy_vector3_new_data(gsize n, gfloat *values)
 }
 
 /**
- * psy_vector3_destroy:
+ * psy_vector3_free:
  * @self: An instance to destroy
  */
 void
-psy_vector3_destroy(PsyVector3 *self)
+psy_vector3_free(PsyVector3 *self)
 {
     g_object_unref(self);
 }

--- a/psy/psy-vector3.h
+++ b/psy/psy-vector3.h
@@ -16,7 +16,7 @@ G_MODULE_EXPORT PsyVector3 *
 psy_vector3_new_data(gsize n, gfloat *values);
 
 G_MODULE_EXPORT void
-psy_vector3_destroy(PsyVector3 *self);
+psy_vector3_free(PsyVector3 *self);
 
 G_MODULE_EXPORT gfloat
 psy_vector3_get_magnitude(PsyVector3 *self);

--- a/psy/psy-vector4.cpp
+++ b/psy/psy-vector4.cpp
@@ -225,11 +225,11 @@ psy_vector4_new_data(gsize n, gfloat *values)
 }
 
 /**
- * psy_vector4_destroy:
+ * psy_vector4_free:
  * @self: An instance to destroy
  */
 void
-psy_vector4_destroy(PsyVector4 *self)
+psy_vector4_free(PsyVector4 *self)
 {
     g_object_unref(self);
 }

--- a/psy/psy-vector4.cpp
+++ b/psy/psy-vector4.cpp
@@ -231,6 +231,7 @@ psy_vector4_new_data(gsize n, gfloat *values)
 void
 psy_vector4_free(PsyVector4 *self)
 {
+    g_return_if_fail(PSY_IS_VECTOR4(self));
     g_object_unref(self);
 }
 

--- a/psy/psy-vector4.h
+++ b/psy/psy-vector4.h
@@ -20,7 +20,7 @@ G_MODULE_EXPORT PsyVector4 *
 psy_vector4_new_data(gsize n, gfloat *values);
 
 G_MODULE_EXPORT void
-psy_vector4_destroy(PsyVector4 *self);
+psy_vector4_free(PsyVector4 *self);
 
 G_MODULE_EXPORT gfloat
 psy_vector4_get_magnitude(PsyVector4 *self);

--- a/psy/psy-visual-stimulus.c
+++ b/psy/psy-visual-stimulus.c
@@ -216,7 +216,7 @@ visual_stimulus_set_color(PsyVisualStimulus *self, PsyColor *color)
     PsyVisualStimulusPrivate *priv
         = psy_visual_stimulus_get_instance_private(self);
     g_clear_object(&priv->color);
-    priv->color = psy_color_dup(color);
+    priv->color = psy_color_copy(color);
 }
 
 static void

--- a/psy/psy-wave.c
+++ b/psy/psy-wave.c
@@ -341,7 +341,7 @@ psy_wave_class_init(PsyWaveClass *klass)
  * 440 Hz.
  *
  * Returns: A new object with default parameters free with g_object_unref or
- *          similar function.
+ *          [method@Wave.free].
  */
 PsyWave *
 psy_wave_new(PsyAudioDevice *device)
@@ -361,7 +361,7 @@ psy_wave_new(PsyAudioDevice *device)
  * 440 Hz.
  *
  * Returns: A new instance with representing a tone with specified volume
- * with g_object_unref or similar function.
+ * with g_object_unref or [method@Wave.free].
  */
 PsyWave *
 psy_wave_new_volume(PsyAudioDevice *device, gdouble volume)
@@ -390,7 +390,7 @@ psy_wave_new_volume(PsyAudioDevice *device, gdouble volume)
  * a frequency higher that half the sampling rate.
  *
  * Returns: A new instance with representing a tone with specified volume
- * with g_object_unref or similar function.
+ * with g_object_unref or [method@Wave.free]
  */
 PsyWave *
 psy_wave_tone_new(PsyAudioDevice *device, gdouble hz, gdouble volume)
@@ -406,6 +406,18 @@ psy_wave_tone_new(PsyAudioDevice *device, gdouble hz, gdouble volume)
     // clang-format on
 
     return wave;
+}
+
+/**
+ * psy_wave_free: (skip)
+ *
+ * frees instances of [class@Wave]
+ */
+void
+psy_wave_free(PsyWave *self)
+{
+    g_return_if_fail(PSY_IS_WAVE(self));
+    g_object_unref(self);
 }
 
 /**

--- a/psy/psy-wave.h
+++ b/psy/psy-wave.h
@@ -20,6 +20,9 @@ psy_wave_new_volume(PsyAudioDevice *device, gdouble volume);
 G_MODULE_EXPORT PsyWave *
 psy_wave_tone_new(PsyAudioDevice *device, gdouble hz, gdouble volume);
 
+G_MODULE_EXPORT void
+psy_wave_free(PsyWave *self);
+
 G_MODULE_EXPORT gdouble
 psy_wave_get_volume(PsyWave *self);
 

--- a/tests/test-audio.c
+++ b/tests/test-audio.c
@@ -16,7 +16,7 @@ typedef struct AudioBackendAllocater {
 PsyAudioDevice *
 alloc_pa_device(void)
 {
-    return psy_pa_device_new();
+    return PSY_AUDIO_DEVICE(psy_pa_device_new());
 }
 
 AudioBackendAllocater pa_allocater = {.alloc = alloc_pa_device};

--- a/tests/test-stepping.c
+++ b/tests/test-stepping.c
@@ -188,7 +188,7 @@ test_basic_loop(void)
     CU_ASSERT_EQUAL(condition, PSY_LOOP_CONDITION_LESS);
     CU_ASSERT_FALSE(psy_loop_test(loop));
 
-    psy_loop_destroy(loop);
+    psy_loop_free(loop);
 
     // test PSY_LOOP_LESS
     index = 0, increment = 1, stop = 5;

--- a/tests/vector-test.c
+++ b/tests/vector-test.c
@@ -11,14 +11,14 @@ test_create(void)
     g_assert(vec != NULL);
     gfloat x, y, z;
 
-    psy_vector_destroy(vec);
+    psy_vector_free(vec);
     vec = psy_vector_new_x(1.0);
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
     g_object_get(vec, "x", &x, "y", &y, "z", &z, NULL);
     CU_ASSERT_DOUBLE_EQUAL(x, 1, 0.0);
     CU_ASSERT_DOUBLE_EQUAL(y, 0, 0.0);
     CU_ASSERT_DOUBLE_EQUAL(z, 0, 0.0);
-    psy_vector_destroy(vec);
+    psy_vector_free(vec);
 
     vec = psy_vector_new_xy(10, 10);
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
@@ -26,7 +26,7 @@ test_create(void)
     CU_ASSERT_DOUBLE_EQUAL(x, 10, 0);
     CU_ASSERT_DOUBLE_EQUAL(y, 10, 0);
     CU_ASSERT_DOUBLE_EQUAL(z, 0, 0);
-    psy_vector_destroy(vec);
+    psy_vector_free(vec);
 
     vec = psy_vector_new_xyz(100, 100, 100);
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
@@ -35,7 +35,7 @@ test_create(void)
     CU_ASSERT_DOUBLE_EQUAL(y, 100, 0.0);
     CU_ASSERT_DOUBLE_EQUAL(z, 100, 0.0);
 
-    psy_vector_destroy(vec);
+    psy_vector_free(vec);
 }
 
 static void
@@ -66,13 +66,13 @@ test_unit(void)
 
     length = psy_vector_magnitude(unit);
     CU_ASSERT_DOUBLE_EQUAL(length, 1.0f, epsilon);
-    psy_vector_destroy(vec);
-    psy_vector_destroy(unit);
+    psy_vector_free(vec);
+    psy_vector_free(unit);
 
     vec  = psy_vector_new();
     unit = psy_vector_unit(vec);
     CU_ASSERT_PTR_NULL(unit);
-    psy_vector_destroy(vec);
+    psy_vector_free(vec);
 }
 
 static void
@@ -93,8 +93,8 @@ test_negate(void)
 
     CU_ASSERT_EQUAL(psy_vector_magnitude(vec), psy_vector_magnitude(negated));
 
-    psy_vector_destroy(vec);
-    psy_vector_destroy(negated);
+    psy_vector_free(vec);
+    psy_vector_free(negated);
 }
 
 static void
@@ -111,8 +111,8 @@ test_add_scalar(void)
     CU_ASSERT_EQUAL(ry, y + scalar);
     CU_ASSERT_EQUAL(rz, z + scalar);
 
-    psy_vector_destroy(vec);
-    psy_vector_destroy(result);
+    psy_vector_free(vec);
+    psy_vector_free(result);
 }
 
 static void
@@ -126,10 +126,10 @@ test_add_vector(void)
 
     CU_ASSERT_TRUE(psy_vector_equals(result, v3));
 
-    psy_vector_destroy(v1);
-    psy_vector_destroy(v2);
-    psy_vector_destroy(v3);
-    psy_vector_destroy(result);
+    psy_vector_free(v1);
+    psy_vector_free(v2);
+    psy_vector_free(v3);
+    psy_vector_free(result);
 }
 
 static void
@@ -145,8 +145,8 @@ test_sub_scalar(void)
     CU_ASSERT_EQUAL(ry, y - scalar);
     CU_ASSERT_EQUAL(rz, z - scalar);
 
-    psy_vector_destroy(vec);
-    psy_vector_destroy(result);
+    psy_vector_free(vec);
+    psy_vector_free(result);
 }
 
 static void
@@ -160,10 +160,10 @@ test_sub_vector(void)
 
     CU_ASSERT_TRUE(psy_vector_equals(result, expected));
 
-    psy_vector_destroy(v1);
-    psy_vector_destroy(v2);
-    psy_vector_destroy(expected);
-    psy_vector_destroy(result);
+    psy_vector_free(v1);
+    psy_vector_free(v2);
+    psy_vector_free(expected);
+    psy_vector_free(result);
 }
 
 static void
@@ -176,9 +176,9 @@ test_mul_scalar(void)
     PsyVector *expected
         = psy_vector_new_xyz(x * scalar, y * scalar, z * scalar);
     CU_ASSERT_TRUE(psy_vector_equals(expected, result));
-    psy_vector_destroy(v1);
-    psy_vector_destroy(result);
-    psy_vector_destroy(expected);
+    psy_vector_free(v1);
+    psy_vector_free(result);
+    psy_vector_free(expected);
 }
 
 static void
@@ -192,8 +192,8 @@ test_vector_dot(void)
 
     cos = psy_vector_dot(v2, v1);
     g_assert(cos == 0);
-    psy_vector_destroy(v1);
-    psy_vector_destroy(v2);
+    psy_vector_free(v1);
+    psy_vector_free(v2);
 }
 
 static void
@@ -211,12 +211,12 @@ test_vector_cross(void)
     result_reversed = psy_vector_cross(v2, v1);
     CU_ASSERT_TRUE(psy_vector_equals(v3min, result_reversed));
 
-    psy_vector_destroy(v1);
-    psy_vector_destroy(v2);
-    psy_vector_destroy(v3);
-    psy_vector_destroy(v3min);
-    psy_vector_destroy(result);
-    psy_vector_destroy(result_reversed);
+    psy_vector_free(v1);
+    psy_vector_free(v2);
+    psy_vector_free(v3);
+    psy_vector_free(v3min);
+    psy_vector_free(result);
+    psy_vector_free(result_reversed);
 }
 
 int

--- a/tests/vector3-test.c
+++ b/tests/vector3-test.c
@@ -11,7 +11,7 @@ test_create(void)
 {
     PsyVector3 *vec = psy_vector3_new();
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
-    psy_vector3_destroy(vec);
+    psy_vector3_free(vec);
 
     gfloat data[3] = {1, 2, 3};
     gfloat x, y, z;
@@ -21,7 +21,7 @@ test_create(void)
     CU_ASSERT_EQUAL(y, data[1]);
     CU_ASSERT_EQUAL(z, data[2]);
 
-    psy_vector3_destroy(vec);
+    psy_vector3_free(vec);
 }
 
 static void
@@ -53,14 +53,14 @@ test_unit(void)
 
     length = psy_vector3_get_magnitude(unit);
     CU_ASSERT_EQUAL(length, 1.0f);
-    psy_vector3_destroy(vec);
-    psy_vector3_destroy(unit);
+    psy_vector3_free(vec);
+    psy_vector3_free(unit);
 
     vec  = psy_vector3_new();
     unit = psy_vector3_unit(vec);
     CU_ASSERT_PTR_NULL(unit);
 
-    psy_vector3_destroy(vec);
+    psy_vector3_free(vec);
 }
 
 static void
@@ -82,8 +82,8 @@ test_negate(void)
     CU_ASSERT_EQUAL(psy_vector3_get_magnitude(vec),
                     psy_vector3_get_magnitude(negated));
 
-    psy_vector3_destroy(vec);
-    psy_vector3_destroy(negated);
+    psy_vector3_free(vec);
+    psy_vector3_free(negated);
 }
 
 static void
@@ -101,8 +101,8 @@ test_add_scalar(void)
     CU_ASSERT_EQUAL(ry, y + scalar);
     CU_ASSERT_EQUAL(rz, z + scalar);
 
-    psy_vector3_destroy(vec);
-    psy_vector3_destroy(result);
+    psy_vector3_free(vec);
+    psy_vector3_free(result);
 }
 
 static void
@@ -117,10 +117,10 @@ test_add_vector(void)
     PsyVector3 *v3     = psy_vector3_mul_s(v1, 2.0);
     CU_ASSERT_TRUE(psy_vector3_equals(result, v3));
 
-    psy_vector3_destroy(v1);
-    psy_vector3_destroy(v2);
-    psy_vector3_destroy(v3);
-    psy_vector3_destroy(result);
+    psy_vector3_free(v1);
+    psy_vector3_free(v2);
+    psy_vector3_free(v3);
+    psy_vector3_free(result);
 }
 
 static void
@@ -137,8 +137,8 @@ test_sub_scalar(void)
     CU_ASSERT_EQUAL(ry, y - scalar);
     CU_ASSERT_EQUAL(rz, z - scalar);
 
-    psy_vector3_destroy(vec);
-    psy_vector3_destroy(result);
+    psy_vector3_free(vec);
+    psy_vector3_free(result);
 }
 
 static void
@@ -150,8 +150,8 @@ test_sub_vector(void)
     PsyVector3 *result = psy_vector3_sub(v1, v1);
     CU_ASSERT_TRUE(psy_vector3_is_null(result));
 
-    psy_vector3_destroy(v1);
-    psy_vector3_destroy(result);
+    psy_vector3_free(v1);
+    psy_vector3_free(result);
 }
 
 static void
@@ -173,9 +173,9 @@ test_mul_scalar(void)
 
     CU_ASSERT_TRUE(psy_vector3_equals(expected, result));
 
-    psy_vector3_destroy(v1);
-    psy_vector3_destroy(result);
-    psy_vector3_destroy(expected);
+    psy_vector3_free(v1);
+    psy_vector3_free(result);
+    psy_vector3_free(expected);
 }
 
 static void
@@ -190,8 +190,8 @@ test_vector_dot(void)
 
     cos = psy_vector3_dot(v2, v1);
     CU_ASSERT_EQUAL(cos, 0.0f);
-    psy_vector3_destroy(v1);
-    psy_vector3_destroy(v2);
+    psy_vector3_free(v1);
+    psy_vector3_free(v2);
 }
 
 int

--- a/tests/vector4-test.c
+++ b/tests/vector4-test.c
@@ -12,7 +12,7 @@ test_create(void)
 {
     PsyVector4 *vec = psy_vector4_new();
     CU_ASSERT_PTR_NOT_NULL_FATAL(vec);
-    psy_vector4_destroy(vec);
+    psy_vector4_free(vec);
 
     gfloat data[4] = {1, 2, 3, 4};
     gfloat x, y, z, w;
@@ -23,7 +23,7 @@ test_create(void)
     CU_ASSERT_EQUAL(z, data[2]);
     CU_ASSERT_EQUAL(w, data[3]);
 
-    psy_vector4_destroy(vec);
+    psy_vector4_free(vec);
 }
 
 static void
@@ -55,14 +55,14 @@ test_unit(void)
 
     length = psy_vector4_get_magnitude(unit);
     CU_ASSERT_EQUAL(length, 1.0f);
-    psy_vector4_destroy(vec);
-    psy_vector4_destroy(unit);
+    psy_vector4_free(vec);
+    psy_vector4_free(unit);
 
     vec  = psy_vector4_new();
     unit = psy_vector4_unit(vec);
     CU_ASSERT_PTR_NULL(unit);
 
-    psy_vector4_destroy(vec);
+    psy_vector4_free(vec);
 }
 
 static void
@@ -84,8 +84,8 @@ test_negate(void)
     CU_ASSERT_EQUAL(psy_vector4_get_magnitude(vec),
                     psy_vector4_get_magnitude(negated));
 
-    psy_vector4_destroy(vec);
-    psy_vector4_destroy(negated);
+    psy_vector4_free(vec);
+    psy_vector4_free(negated);
 }
 
 static void
@@ -104,8 +104,8 @@ test_add_scalar(void)
     CU_ASSERT_EQUAL(rz, z + scalar);
     CU_ASSERT_EQUAL(rw, w + scalar);
 
-    psy_vector4_destroy(vec);
-    psy_vector4_destroy(result);
+    psy_vector4_free(vec);
+    psy_vector4_free(result);
 }
 
 static void
@@ -120,10 +120,10 @@ test_add_vector(void)
     PsyVector4 *v3     = psy_vector4_mul_s(v1, 2.0);
     CU_ASSERT_TRUE(psy_vector4_equals(result, v3));
 
-    psy_vector4_destroy(v1);
-    psy_vector4_destroy(v2);
-    psy_vector4_destroy(v3);
-    psy_vector4_destroy(result);
+    psy_vector4_free(v1);
+    psy_vector4_free(v2);
+    psy_vector4_free(v3);
+    psy_vector4_free(result);
 }
 
 static void
@@ -141,8 +141,8 @@ test_sub_scalar(void)
     CU_ASSERT_EQUAL(rz, z - scalar);
     CU_ASSERT_EQUAL(rw, w - scalar);
 
-    psy_vector4_destroy(vec);
-    psy_vector4_destroy(result);
+    psy_vector4_free(vec);
+    psy_vector4_free(result);
 }
 
 static void
@@ -154,8 +154,8 @@ test_sub_vector(void)
     PsyVector4 *result = psy_vector4_sub(v1, v1);
     CU_ASSERT_TRUE(psy_vector4_is_null(result));
 
-    psy_vector4_destroy(v1);
-    psy_vector4_destroy(result);
+    psy_vector4_free(v1);
+    psy_vector4_free(result);
 }
 
 static void
@@ -178,9 +178,9 @@ test_mul_scalar(void)
 
     CU_ASSERT_TRUE(psy_vector4_equals(expected, result));
 
-    psy_vector4_destroy(v1);
-    psy_vector4_destroy(result);
-    psy_vector4_destroy(expected);
+    psy_vector4_free(v1);
+    psy_vector4_free(result);
+    psy_vector4_free(expected);
 }
 
 static void
@@ -195,8 +195,8 @@ test_vector_dot(void)
 
     cos = psy_vector4_dot(v2, v1);
     CU_ASSERT_EQUAL(cos, 0.0f);
-    psy_vector4_destroy(v1);
-    psy_vector4_destroy(v2);
+    psy_vector4_free(v1);
+    psy_vector4_free(v2);
 }
 
 int


### PR DESCRIPTION
Makes naming throughout psylib more consistent.

1. All objects/structs have a *_new() function in order to create them
2. All objects have a psy_*_free() function to free the resources associated with them
3. All objects have a copy function when they a deep copy of them is made

fixes #70