### PR TITLE
Rm debug prints in favor of logging

### DIFF
--- a/psy/psy-trial.c
+++ b/psy/psy-trial.c
@@ -22,7 +22,7 @@ psy_trial_init(PsyTrial *trial)
 /**
  * psy_trial_new:(constructor)
  *
- * Create a new trial, to be freed with g_object_unref or [method@Tria.free]
+ * Create a new trial, to be freed with g_object_unref or [method@Trial.free]
  *
  * Returns: a new [class@Trial] instance
  */

--- a/tests/test-audio.c
+++ b/tests/test-audio.c
@@ -134,7 +134,7 @@ audio_device_open(void)
     GError         *error = NULL;
     GMainLoop      *loop  = g_main_loop_new(NULL, FALSE);
 
-    g_print("Device = %p\n", (void *) device);
+    g_info("Device = %p\n", (void *) device);
 
     OnStarted cb_data   = {.loop = loop, .started = FALSE};
     OnStop    stop_data = {.loop = loop, .device = device};

--- a/tests/test-image.c
+++ b/tests/test-image.c
@@ -2,9 +2,24 @@
 #include <math.h>
 #include <string.h>
 
+#include "unit-test-utilities.h"
 #include <CUnit/CUnit.h>
 
 #include <psylib.h>
+
+static int
+image_setup(void)
+{
+    set_log_handler_file("test-image.txt");
+    return 0;
+}
+
+static int
+image_teardown(void)
+{
+    set_log_handler_file(NULL);
+    return 0;
+}
 
 static void
 test_image_create1(void)
@@ -104,8 +119,9 @@ test_image_change_format(void)
 int
 add_image_suite(void)
 {
-    CU_Suite *suite = CU_add_suite("PsyImage suite", NULL, NULL);
-    CU_Test  *test;
+    CU_Suite *suite
+        = CU_add_suite("PsyImage suite", image_setup, image_teardown);
+    CU_Test *test;
     if (!suite)
         return 1;
 

--- a/tests/test-picture.c
+++ b/tests/test-picture.c
@@ -95,6 +95,7 @@ init_squares(PsyImage *image)
 static int
 picture_setup(void)
 {
+    set_log_handler_file("test-picture.txt");
     GError *error = NULL;
     g_image  = psy_image_new(g_img_width, g_img_height, PSY_IMAGE_FORMAT_RGB);
     g_canvas = psy_image_canvas_new(g_canvas_width, g_canvas_height);
@@ -137,10 +138,12 @@ picture_teardown(void)
 
     g_file_delete(file, NULL, &error);
     if (error) {
-        g_printerr("Unable to delete %s:%s\n", g_path, error->message);
+        g_warning("Unable to delete %s:%s\n", g_path, error->message);
     }
     g_object_unref(file);
     g_free(g_path);
+
+    set_log_handler_file(NULL);
 
     return 0;
 }
@@ -280,7 +283,7 @@ test_colors(PsyImage *image)
             // to a float, hence we allow a epsilon of one rgba value
             if (!psy_color_equal_eps(bg, probe, (1.0f / 255))) {
                 ret = FALSE;
-                g_printerr(
+                g_warning(
                     "point (%u, %u) is not equal to the background.\n", x, y);
             }
         }
@@ -289,15 +292,13 @@ test_colors(PsyImage *image)
             guint ix = x - (g_canvas_width - g_img_width) / 2;
             guint iy = y - (g_canvas_height - g_img_height) / 2;
 
-            // g_print("x = %u, y = %u, ix = %u, iy = %u\n", x, y, ix, iy);
-
             g_assert(ix < g_img_width);
             g_assert(iy < g_img_height);
 
             if (is_upper_left(g_img_width, g_img_height, iy, ix)) {
                 if (!psy_color_equal(red, probe)) {
                     ret = FALSE;
-                    g_printerr(
+                    g_warning(
                         "point g(%u, %u), i(%u, %u) is not equal to red.\n",
                         x,
                         y,
@@ -308,7 +309,7 @@ test_colors(PsyImage *image)
             else if (is_upper_right(g_img_width, g_img_height, iy, ix)) {
                 if (!psy_color_equal(green, probe)) {
                     ret = FALSE;
-                    g_printerr(
+                    g_warning(
                         "point g(%u, %u), i(%u, %u) is not equal to green.\n",
                         x,
                         y,
@@ -319,7 +320,7 @@ test_colors(PsyImage *image)
             else if (is_lower_left(g_img_width, g_img_height, iy, ix)) {
                 if (!psy_color_equal(blue, probe)) {
                     ret = FALSE;
-                    g_printerr(
+                    g_warning(
                         "point g(%u, %u), i(%u, %u) is not equal to blue.\n",
                         x,
                         y,
@@ -330,7 +331,7 @@ test_colors(PsyImage *image)
             else if (is_lower_right(g_img_width, g_img_height, iy, ix)) {
                 if (!psy_color_equal(purple, probe)) {
                     ret = FALSE;
-                    g_printerr(
+                    g_warning(
                         "point g(%u, %u), i(%u, %u) is not equal to purple.\n",
                         x,
                         y,
@@ -339,11 +340,11 @@ test_colors(PsyImage *image)
                 }
             }
             else {
-                g_printerr("No sensible coordinate x=%u, y=%u; ix=%u, iy=%u\n",
-                           x,
-                           y,
-                           ix,
-                           iy);
+                g_warning("No sensible coordinate x=%u, y=%u; ix=%u, iy=%u\n",
+                          x,
+                          y,
+                          ix,
+                          iy);
                 g_assert_not_reached();
             }
         }

--- a/tests/test-stepping.c
+++ b/tests/test-stepping.c
@@ -332,7 +332,6 @@ typedef struct StoneParams {
 static void
 on_stones_enter(PsyStep *step, gint64 timestamp, gpointer data)
 {
-    // g_print("%s\n", __func__);
     g_assert(PSY_IS_STEPPING_STONES(step));
     (void) step;
     (void) timestamp;
@@ -343,7 +342,6 @@ on_stones_enter(PsyStep *step, gint64 timestamp, gpointer data)
 static void
 on_stones_leave(PsyStep *step, gint64 timestamp, gpointer data)
 {
-    // g_print("%s\n", __func__);
     (void) step;
     (void) timestamp;
 
@@ -354,7 +352,6 @@ on_stones_leave(PsyStep *step, gint64 timestamp, gpointer data)
 static void
 on_stones_trial_enter(PsyStep *step, gint64 timestamp, gpointer data)
 {
-    // g_print("%s\n", __func__);
     (void) timestamp;
     StoneParams *pars = data;
     PsyClock    *clk  = psy_clock_new();
@@ -373,7 +370,6 @@ on_stones_loop_iterate(PsyLoop *loop,
                        gint64   timestamp,
                        gpointer data)
 {
-    // g_print("%s\n", __func__);
     StoneParams *pars = data;
     (void) index;
     (void) timestamp;

--- a/tests/test-visual-stimulus.c
+++ b/tests/test-visual-stimulus.c
@@ -16,8 +16,9 @@ static PsyColor       *g_bg_color   = NULL;
 static PsyTimePoint *g_tp_start     = NULL;
 
 static int
-test_visual_stimulus_setup(void)
+visual_stimulus_setup(void)
 {
+    set_log_handler_file("test-visual-stimulus.txt");
     g_debug("Entering %s", __func__);
     g_canvas     = psy_image_canvas_new(WIDTH, HEIGHT);
     g_stim_color = psy_color_new_rgbi(random_int_range(0, 255),
@@ -46,13 +47,15 @@ test_visual_stimulus_setup(void)
 }
 
 static int
-test_visual_stimulus_teardown(void)
+visual_stimulus_teardown(void)
 {
     g_debug("Entering %s", __func__);
     g_clear_object(&g_canvas);
     g_clear_object(&g_stim_color);
     g_clear_object(&g_bg_color);
     g_clear_pointer(&g_tp_start, psy_time_point_free);
+
+    set_log_handler_file(NULL);
 
     return 0;
 }
@@ -305,8 +308,7 @@ vstim_translate(void)
                                avg_y,
                                &avg_x,
                                &avg_y);
-    g_printerr(
-        "\ntx =%lf, ty%lf, avg_x=%lf, avg_y=%lf\n", tx, ty, avg_x, avg_y);
+    g_info("\ntx =%lf, ty%lf, avg_x=%lf, avg_y=%lf\n", tx, ty, avg_x, avg_y);
     CU_ASSERT_DOUBLE_EQUAL(avg_x, tx, 1);
     CU_ASSERT_DOUBLE_EQUAL(avg_y, ty, 1);
 
@@ -720,8 +722,8 @@ int
 add_visual_stimulus_suite(void)
 {
     CU_Suite *suite = CU_add_suite("Visual stimulus suite",
-                                   test_visual_stimulus_setup,
-                                   test_visual_stimulus_teardown);
+                                   visual_stimulus_setup,
+                                   visual_stimulus_teardown);
 
     CU_Test *test = NULL;
 

--- a/tests/test-wave.c
+++ b/tests/test-wave.c
@@ -13,7 +13,7 @@ typedef struct {
 } WaveStatus;
 
 static int
-create_audio_device(void)
+wave_setup(void)
 {
     set_log_handler_file("test-wave.txt");
 
@@ -43,7 +43,7 @@ create_audio_device(void)
 }
 
 static int
-destroy_audio_device(void)
+wave_teardown(void)
 {
     psy_audio_device_close(g_device);
     g_message("%s: g_device refcount = %u",
@@ -188,7 +188,7 @@ test_wave_play(void)
     psy_audio_device_start(g_device, &error);
     CU_ASSERT_PTR_NULL(error);
     if (error) {
-        g_printerr("Unable to start the audio device: %s\n", error->message);
+        g_error("Unable to start the audio device: %s\n", error->message);
         g_clear_error(&error);
     }
 
@@ -249,7 +249,7 @@ test_wave_play_noise(void)
     psy_audio_device_start(g_device, &error);
     CU_ASSERT_PTR_NULL(error);
     if (error) {
-        g_printerr("Unable to start the audio device: %s\n", error->message);
+        g_error("Unable to start the audio device: %s\n", error->message);
         g_clear_error(&error);
     }
 
@@ -277,9 +277,8 @@ test_wave_play_noise(void)
 int
 add_wave_suite(void)
 {
-    CU_Suite *suite = CU_add_suite(
-        "audio tests", create_audio_device, destroy_audio_device);
-    CU_Test *test = NULL;
+    CU_Suite *suite = CU_add_suite("audio tests", wave_setup, wave_teardown);
+    CU_Test  *test  = NULL;
 
     if (!suite)
         return 1;


### PR DESCRIPTION
There were some points in the unit tests where print statments was preferred over logging, this is replaced by logging now.

fixes #64