### PR TITLE
Feature hidden symbols

### DIFF
--- a/psy/backend_gtk/psy-gtk-window.h
+++ b/psy/backend_gtk/psy-gtk-window.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GTK_WINDOW psy_gtk_window_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyGtkWindow, psy_gtk_window, PSY, GTK_WINDOW, PsyWindow)
 
 G_MODULE_EXPORT PsyGtkWindow *

--- a/psy/gl/psy-gl-canvas.h
+++ b/psy/gl/psy-gl-canvas.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_CANVAS psy_gl_canvas_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyGlCanvas, psy_gl_canvas, PSY, GL_CANVAS, PsyImageCanvas)
 
 G_MODULE_EXPORT PsyGlCanvas *

--- a/psy/gl/psy-gl-context.h
+++ b/psy/gl/psy-gl-context.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_CONTEXT psy_gl_context_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyGlContext, psy_gl_context, PSY, GL_CONTEXT, PsyDrawingContext)
 

--- a/psy/gl/psy-gl-fragment-shader.h
+++ b/psy/gl/psy-gl-fragment-shader.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_FRAGMENT_SHADER psy_gl_fragment_shader_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyGlFragmentShader,
                      psy_gl_fragment_shader,
                      PSY,

--- a/psy/gl/psy-gl-program.h
+++ b/psy/gl/psy-gl-program.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_PROGRAM psy_gl_program_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyGlProgram, psy_gl_program, PSY, GL_PROGRAM, PsyShaderProgram)
 

--- a/psy/gl/psy-gl-shader.h
+++ b/psy/gl/psy-gl-shader.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_SHADER psy_gl_shader_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyGlShader, psy_gl_shader, PSY, GL_SHADER, PsyShader)
 
 typedef struct _PsyGlShaderClass {

--- a/psy/gl/psy-gl-texture.h
+++ b/psy/gl/psy-gl-texture.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_TEXTURE psy_gl_texture_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyGlTexture, psy_gl_texture, PSY, GL_TEXTURE, PsyTexture)
 
 /*

--- a/psy/gl/psy-gl-vbuffer.h
+++ b/psy/gl/psy-gl-vbuffer.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_VBUFFER psy_gl_vbuffer_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyGlVBuffer, psy_gl_vbuffer, PSY, GL_VBUFFER, PsyVBuffer)
 
 G_MODULE_EXPORT PsyGlVBuffer *

--- a/psy/gl/psy-gl-vertex-shader.h
+++ b/psy/gl/psy-gl-vertex-shader.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GL_VERTEX_SHADER psy_gl_vertex_shader_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyGlVertexShader, psy_gl_vertex_shader, PSY, GL_VERTEX_SHADER, PsyGlShader)
 

--- a/psy/hw/psy-parallel-port.h
+++ b/psy/hw/psy-parallel-port.h
@@ -9,6 +9,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_PARALLEL_PORT psy_parallel_port_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyParallelPort, psy_parallel_port, PSY, PARALLEL_PORT, GObject)
 

--- a/psy/hw/psy-parallel-trigger.h
+++ b/psy/hw/psy-parallel-trigger.h
@@ -14,6 +14,8 @@ G_MODULE_EXPORT GQuark
 psy_parallel_trigger_error_quark(void);
 
 #define PSY_TYPE_PARALLEL_TRIGGER psy_parallel_trigger_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyParallelTrigger, psy_parallel_trigger, PSY, PARALLEL_TRIGGER, GObject)
 

--- a/psy/hw/psy-parport.h
+++ b/psy/hw/psy-parport.h
@@ -7,6 +7,7 @@ G_BEGIN_DECLS
 
 #define PSY_TYPE_PARPORT psy_parport_get_type()
 
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyParport, psy_parport, PSY, PARPORT, PsyParallelPort)
 
 G_END_DECLS

--- a/psy/jack/psy-jack-audio-device.h
+++ b/psy/jack/psy-jack-audio-device.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_JACK_AUDIO_DEVICE psy_jack_audio_device_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyJackAudioDevice,
                      psy_jack_audio_device,
                      PSY,

--- a/psy/meson.build
+++ b/psy/meson.build
@@ -215,7 +215,12 @@ if get_option('portaudio')
 endif
 
 
-enum_files = gnome.mkenums_simple('enum-types', sources : libpsy_headers)
+enum_files = gnome.mkenums_simple(
+    'enum-types',
+    header_prefix : '#include<gio/gio.h>',
+    decorator : 'G_MODULE_EXPORT',
+    sources : libpsy_headers
+)
 
 configure_file(input : 'v-shader.vert',
                output: 'v-shader.vert',
@@ -257,7 +262,7 @@ libpsy = library (
     c_args : PP_ARGS,
     cpp_args : PP_ARGS,
     install: true,
-    symbol_visibility: 'hidden'
+    gnu_symbol_visibility: 'hidden'
 )
 
 libpsy_dep = declare_dependency(

--- a/psy/meson.build
+++ b/psy/meson.build
@@ -256,7 +256,8 @@ libpsy = library (
     include_directories : [libpsy_incdirs, config_incdirs],
     c_args : PP_ARGS,
     cpp_args : PP_ARGS,
-    install: true
+    install: true,
+    symbol_visibility: 'hidden'
 )
 
 libpsy_dep = declare_dependency(

--- a/psy/portaudio/psy-pa-device.h
+++ b/psy/portaudio/psy-pa-device.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_PA_DEVICE psy_pa_device_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyPADevice, psy_pa_device, PSY, PA_DEVICE, PsyAudioDevice)
 
 G_MODULE_EXPORT PsyPADevice *

--- a/psy/psy-artist.h
+++ b/psy/psy-artist.h
@@ -17,6 +17,7 @@ struct _PsyCanvas;
 typedef struct _PsyCanvas PsyCanvas;
 
 #define PSY_TYPE_ARTIST psy_artist_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyArtist, psy_artist, PSY, ARTIST, GObject)
 
 /**

--- a/psy/psy-audio-device.h
+++ b/psy/psy-audio-device.h
@@ -50,10 +50,10 @@ typedef struct PsyAudioDeviceInfo {
     guint private_index;
 } PsyAudioDeviceInfo;
 
-GType
+G_MODULE_EXPORT GType
 psy_audio_device_info_get_type(void);
 
-PsyAudioDeviceInfo *
+G_MODULE_EXPORT PsyAudioDeviceInfo *
 psy_audio_device_info_new(gint                device_num,
                           gchar              *psy_api,
                           gchar              *host_api,
@@ -64,21 +64,21 @@ psy_audio_device_info_new(gint                device_num,
                           guint               num_sample_rates,
                           guint               private_index);
 
-void
+G_MODULE_EXPORT void
 psy_audio_device_info_get_sample_rates(PsyAudioDeviceInfo  *self,
                                        PsyAudioSampleRate **sample_rates,
                                        guint               *num_sample_rates);
 
-PsyAudioDeviceInfo *
+G_MODULE_EXPORT PsyAudioDeviceInfo *
 psy_audio_device_info_copy(PsyAudioDeviceInfo *self);
 
-void
+G_MODULE_EXPORT void
 psy_audio_device_info_free(PsyAudioDeviceInfo *self);
 
-char *
+G_MODULE_EXPORT char *
 psy_audio_device_info_as_string(PsyAudioDeviceInfo *self);
 
-gboolean
+G_MODULE_EXPORT gboolean
 psy_audio_device_info_contains_sr(PsyAudioDeviceInfo *self,
                                   PsyAudioSampleRate  sr);
 
@@ -87,6 +87,7 @@ G_MODULE_EXPORT GQuark
 psy_audio_device_error_quark(void);
 
 #define PSY_TYPE_AUDIO_DEVICE psy_audio_device_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyAudioDevice, psy_audio_device, PSY, AUDIO_DEVICE, GObject)
 
@@ -210,7 +211,7 @@ void
 psy_audio_device_schedule_stimulus(PsyAudioDevice      *self,
                                    PsyAuditoryStimulus *stim);
 
-void
+G_MODULE_EXPORT void
 psy_audio_device_enumerate_devices(PsyAudioDevice       *self,
                                    PsyAudioDeviceInfo ***infos,
                                    guint                *n_infos);

--- a/psy/psy-audio-mixer.h
+++ b/psy/psy-audio-mixer.h
@@ -19,6 +19,7 @@ typedef struct _PsyAudioDevice      PsyAudioDevice;
 typedef struct _PsyAuditoryStimulus PsyAuditoryStimulus;
 
 #define PSY_TYPE_AUDIO_MIXER psy_audio_mixer_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyAudioMixer, psy_audio_mixer, PSY, AUDIO_MIXER, GObject)
 

--- a/psy/psy-audio-utils.h
+++ b/psy/psy-audio-utils.h
@@ -11,13 +11,13 @@
 extern "C" {
 #endif
 
-PsyAudioSampleRate
+G_MODULE_EXPORT PsyAudioSampleRate
 psy_int_to_sample_rate(gint sample_rate);
 
-PsyDuration *
+G_MODULE_EXPORT PsyDuration *
 psy_num_audio_samples_to_duration(gint64 num_samples, PsyAudioSampleRate sr);
 
-gint64
+G_MODULE_EXPORT gint64
 psy_duration_to_num_audio_frames(PsyDuration *dur, PsyAudioSampleRate sr);
 
 #ifdef __cplusplus

--- a/psy/psy-auditory-stimulus.h
+++ b/psy/psy-auditory-stimulus.h
@@ -10,6 +10,7 @@ typedef struct _PsyAudioDevice PsyAudioDevice;
 G_BEGIN_DECLS
 
 #define PSY_TYPE_AUDITORY_STIMULUS psy_auditory_stimulus_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyAuditoryStimulus,
                          psy_auditory_stimulus,
                          PSY,

--- a/psy/psy-canvas.h
+++ b/psy/psy-canvas.h
@@ -13,6 +13,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CANVAS psy_canvas_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyCanvas, psy_canvas, PSY, CANVAS, GObject)
 
 /* Forward declaration of PsyArtist and PsyVisualStimulus*/

--- a/psy/psy-circle-artist.h
+++ b/psy/psy-circle-artist.h
@@ -8,6 +8,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CIRCLE_ARTIST psy_circle_artist_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyCircleArtist, psy_circle_artist, PSY, CIRCLE_ARTIST, PsyArtist)
 

--- a/psy/psy-circle.h
+++ b/psy/psy-circle.h
@@ -6,6 +6,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CIRCLE psy_circle_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyCircle, psy_circle, PSY, CIRCLE, PsyVisualStimulus)
 
 typedef struct _PsyCircleClass {

--- a/psy/psy-clock.h
+++ b/psy/psy-clock.h
@@ -6,6 +6,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CLOCK psy_clock_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyClock, psy_clock, PSY, CLOCK, GObject)
 
 G_MODULE_EXPORT PsyClock *

--- a/psy/psy-color.h
+++ b/psy/psy-color.h
@@ -8,11 +8,11 @@
 G_BEGIN_DECLS
 
 /**
- * PSY_TYPE_RGB:
+ * PSY_TYPE_RGBA:
  *
  * The #GType for a boxed holding a floating point RGB range
  */
-#define PSY_TYPE_RGB (psy_rgba_get_type())
+#define PSY_TYPE_RGBA (psy_rgba_get_type())
 G_MODULE_EXPORT GType
 psy_rgba_get_type(void);
 
@@ -48,6 +48,7 @@ psy_rgba_free(PsyRgba *self);
 /* ******* psy-color ********** */
 
 #define PSY_TYPE_COLOR psy_color_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyColor, psy_color, PSY, COLOR, GObject)
 
 G_MODULE_EXPORT PsyColor *

--- a/psy/psy-cross-artist.h
+++ b/psy/psy-cross-artist.h
@@ -8,6 +8,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CROSS_ARTIST psy_cross_artist_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyCrossArtist, psy_cross_artist, PSY, CROSS_ARTIST, PsyArtist)
 

--- a/psy/psy-cross.h
+++ b/psy/psy-cross.h
@@ -6,6 +6,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_CROSS psy_cross_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyCross, psy_cross, PSY, CROSS, PsyVisualStimulus)
 
 typedef struct _PsyCrossClass {

--- a/psy/psy-drawing-context.h
+++ b/psy/psy-drawing-context.h
@@ -15,6 +15,7 @@ G_MODULE_EXPORT GQuark
 psy_drawing_context_error_quark(void);
 
 #define PSY_TYPE_DRAWING_CONTEXT psy_drawing_context_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyDrawingContext, psy_drawing_context, PSY, DRAWING_CONTEXT, GObject)
 

--- a/psy/psy-font-utils.c
+++ b/psy/psy-font-utils.c
@@ -1,4 +1,6 @@
 
+#include <psy-font-utils.h>
+
 #include <pango/pangocairo.h>
 
 /**
@@ -12,7 +14,7 @@
  * it as an error.
  */
 void
-psy_enumerate_font_families(gchar ***families, gsize *n)
+psy_enumerate_font_families(gchar ***families, gint *n)
 {
     PangoFontMap *fm = pango_cairo_font_map_get_default();
 

--- a/psy/psy-gst-stimulus.h
+++ b/psy/psy-gst-stimulus.h
@@ -9,6 +9,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_GST_STIMULUS psy_gst_stimulus_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyGstStimulus, psy_gst_stimulus, PSY, GST_STIMULUS, PsyAuditoryStimulus)
 

--- a/psy/psy-image-canvas.h
+++ b/psy/psy-image-canvas.h
@@ -8,6 +8,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_IMAGE_CANVAS psy_image_canvas_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyImageCanvas, psy_image_canvas, PSY, IMAGE_CANVAS, PsyCanvas)
 

--- a/psy/psy-image.h
+++ b/psy/psy-image.h
@@ -8,6 +8,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_IMAGE psy_image_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyImage, psy_image, PSY, IMAGE, GObject)
 
 G_MODULE_EXPORT PsyImage *
@@ -73,7 +74,7 @@ psy_image_pixel_num_bytes(PsyImage *self);
 G_MODULE_EXPORT void
 psy_image_flip_upside_down(PsyImage *self);
 
-guint8 *
+G_MODULE_EXPORT guint8 *
 psy_image_get_ptr(PsyImage *self);
 
 G_END_DECLS

--- a/psy/psy-loop.h
+++ b/psy/psy-loop.h
@@ -9,6 +9,7 @@ G_BEGIN_DECLS
 
 #define PSY_TYPE_LOOP psy_loop_get_type()
 
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyLoop, psy_loop, PSY, LOOP, PsyStep)
 
 struct _PsyLoopClass {

--- a/psy/psy-matrix4.h
+++ b/psy/psy-matrix4.h
@@ -11,6 +11,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_MATRIX4 psy_matrix4_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyMatrix4, psy_matrix4, PSY, MATRIX4, GObject)
 
 G_MODULE_EXPORT PsyMatrix4 *

--- a/psy/psy-picture-artist.h
+++ b/psy/psy-picture-artist.h
@@ -7,6 +7,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_PICTURE_ARTIST psy_picture_artist_get_type()
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyPictureArtist, psy_picture_artist, PSY, PICTURE_ARTIST, PsyArtist)
 

--- a/psy/psy-picture.h
+++ b/psy/psy-picture.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_PICTURE psy_picture_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyPicture, psy_picture, PSY, PICTURE, PsyRectangle)
 
 typedef struct _PsyPictureClass {

--- a/psy/psy-rectangle-artist.h
+++ b/psy/psy-rectangle-artist.h
@@ -8,6 +8,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_RECTANGLE_ARTIST psy_rectangle_artist_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyRectangleArtist, psy_rectangle_artist, PSY, RECTANGLE_ARTIST, PsyArtist)
 

--- a/psy/psy-rectangle.h
+++ b/psy/psy-rectangle.h
@@ -6,6 +6,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_RECTANGLE psy_rectangle_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyRectangle, psy_rectangle, PSY, RECTANGLE, PsyVisualStimulus)
 

--- a/psy/psy-shader-program.h
+++ b/psy/psy-shader-program.h
@@ -9,6 +9,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_SHADER_PROGRAM psy_shader_program_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyShaderProgram, psy_shader_program, PSY, SHADER_PROGRAM, GObject)
 

--- a/psy/psy-shader.h
+++ b/psy/psy-shader.h
@@ -7,6 +7,7 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_SHADER psy_shader_get_type()
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyShader, psy_shader, PSY, SHADER, GObject)
 
 typedef struct _PsyShaderClass {

--- a/psy/psy-side-step.h
+++ b/psy/psy-side-step.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_SIDE_STEP psy_side_step_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsySideStep, psy_side_step, PSY, SIDE_STEP, PsyStep)
 
 G_MODULE_EXPORT PsySideStep *

--- a/psy/psy-sound-sink.h
+++ b/psy/psy-sound-sink.h
@@ -1,11 +1,13 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <glib-object.h>
 
 G_BEGIN_DECLS
 
 #define PSY_TYPE_SINK psy_sound_sink_get_type()
+G_MODULE_EXPORT
 G_DECLARE_INTERFACE(PsySoundSink, psy_sound_sink, PSY, SOUND_SINK, GObject)
 
 struct _PsySoundSink {
@@ -15,7 +17,7 @@ struct _PsySoundSink {
     void (*pull_audio)(PsySoundSink *self);
 };
 
-gsize
+G_MODULE_EXPORT gsize
 psy_sound_sink_write(PsySoundSink *self, gfloat *sound_signals, gsize nframes);
 
 G_END_DECLS

--- a/psy/psy-step.h
+++ b/psy/psy-step.h
@@ -8,10 +8,13 @@
 G_BEGIN_DECLS
 
 #define PSY_STEP_ERROR psy_step_error_quark()
+
 G_MODULE_EXPORT GQuark
 psy_step_error_quark(void);
 
 #define PSY_TYPE_STEP psy_step_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyStep, psy_step, PSY, STEP, GObject)
 
 /**
@@ -22,17 +25,17 @@ G_DECLARE_DERIVABLE_TYPE(PsyStep, psy_step, PSY, STEP, GObject)
  * @on_leave: This virtual function is called when you are leaving the current
  *            step. It will notify it's parent that you are done, so a parent
  *            loop may start a new iteration or a SteppingStones will step
- *            to it's next added step. You can do something to 
+ *            to it's next added step. You can do something to
  * @activate: This method is called to do something. The activated step,
  *            for a trial means to present stimuli, whereas for a
  *            [class@SteppingStones] or [class@Loop] it would mean to
  *            enter one of its children
  * @post_activate: This is triggered when step is about to be deactivated
  *            This allows loops for example to update the index of the loop.
- *            So when the trial is 
+ *            So when the trial is
  * @deactivate: A function that is called when you are leaving the current
- *            trial. Eventually this will reactivate its parent. 
- *              
+ *            trial. Eventually this will reactivate its parent.
+ *
  */
 struct _PsyStepClass {
     GObjectClass parent;
@@ -64,13 +67,13 @@ G_MODULE_EXPORT void
 psy_step_activate(PsyStep *self, PsyTimePoint *timestamp);
 
 G_MODULE_EXPORT gboolean
-psy_step_get_active(PsyStep* self);
+psy_step_get_active(PsyStep *self);
 
 G_MODULE_EXPORT gint64
-psy_step_get_loop_index(PsyStep* self, guint nth_loop, GError** error);
+psy_step_get_loop_index(PsyStep *self, guint nth_loop, GError **error);
 
 G_MODULE_EXPORT void
-psy_step_get_loop_indices(PsyStep* self, gint64** result, guint* size);
+psy_step_get_loop_indices(PsyStep *self, gint64 **result, guint *size);
 
 G_MODULE_EXPORT GMainContext *
 psy_step_get_main_context(PsyStep *self);

--- a/psy/psy-stepping-stones.h
+++ b/psy/psy-stepping-stones.h
@@ -9,10 +9,13 @@
 G_BEGIN_DECLS
 
 #define PSY_STEPPING_STONES_ERROR psy_stepping_stones_error_quark()
+
 G_MODULE_EXPORT GQuark
 psy_stepping_stones_error_quark(void);
 
 #define PSY_TYPE_STEPPING_STONES psy_stepping_stones_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsySteppingStones, psy_stepping_stones, PSY, STEPPING_STONES, PsyStep)
 

--- a/psy/psy-stimulus.h
+++ b/psy/psy-stimulus.h
@@ -8,6 +8,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_STIMULUS psy_stimulus_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyStimulus, psy_stimulus, PSY, STIMULUS, GObject)
 
 typedef struct _PsyStimulusClass {

--- a/psy/psy-text-artist.h
+++ b/psy/psy-text-artist.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_TEXT_ARTIST psy_text_artist_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(
     PsyTextArtist, psy_text_artist, PSY, TEXT_ARTIST, PsyArtist)
 

--- a/psy/psy-text.h
+++ b/psy/psy-text.h
@@ -8,6 +8,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_TEXT psy_text_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyText, psy_text, PSY, TEXT, PsyRectangle)
 
 /**

--- a/psy/psy-texture.h
+++ b/psy/psy-texture.h
@@ -10,10 +10,13 @@
 G_BEGIN_DECLS
 
 #define PSY_TEXTURE_ERROR psy_texture_error_quark()
-GQuark
+
+G_MODULE_EXPORT GQuark
 psy_texture_error_quark(void);
 
 #define PSY_TYPE_TEXTURE psy_texture_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyTexture, psy_texture, PSY, TEXTURE, GObject)
 
 typedef struct _PsyTextureClass {

--- a/psy/psy-trial.h
+++ b/psy/psy-trial.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_TRIAL psy_trial_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyTrial, psy_trial, PSY, TRIAL, PsyStep)
 
 G_MODULE_EXPORT PsyTrial *

--- a/psy/psy-vbuffer.h
+++ b/psy/psy-vbuffer.h
@@ -8,6 +8,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_VBUFFER psy_vbuffer_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyVBuffer, psy_vbuffer, PSY, VBUFFER, GObject)
 
 typedef struct PsyVertexPos {

--- a/psy/psy-vector.h
+++ b/psy/psy-vector.h
@@ -1,11 +1,14 @@
 #ifndef PSY_VECTOR_H
 #define PSY_VECTOR_H
 
+#include <gio/gio.h>
 #include <glib-object.h>
 
 G_BEGIN_DECLS
 
 #define PSY_TYPE_VECTOR psy_vector_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyVector, psy_vector, PSY, VECTOR, GObject)
 
 typedef struct _PsyVector PsyVector;
@@ -15,45 +18,55 @@ struct _PsyVector {
     gfloat  array[3];
 };
 
-PsyVector *
+G_MODULE_EXPORT PsyVector *
 psy_vector_new(void);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_new_x(gfloat x);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_new_xy(gfloat x, gfloat y);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_new_xyz(gfloat x, gfloat y, gfloat z);
 
-void
+G_MODULE_EXPORT void
 psy_vector_free(PsyVector *self);
 
-gfloat
+G_MODULE_EXPORT gfloat
 psy_vector_magnitude(PsyVector *self);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_unit(PsyVector *self);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_negate(PsyVector *self);
 
-PsyVector *
+G_MODULE_EXPORT PsyVector *
 psy_vector_add_s(PsyVector *self, gfloat scalar);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_add(PsyVector *self, PsyVector *other);
 
-PsyVector *
+G_MODULE_EXPORT PsyVector *
 psy_vector_sub_s(PsyVector *self, gfloat scalar);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_sub(PsyVector *self, PsyVector *other);
 
-PsyVector *
+G_MODULE_EXPORT PsyVector *
 psy_vector_mul_s(PsyVector *self, gfloat scalar);
-gfloat
+
+G_MODULE_EXPORT gfloat
 psy_vector_dot(PsyVector *self, PsyVector *other);
-PsyVector *
+
+G_MODULE_EXPORT PsyVector *
 psy_vector_cross(PsyVector *self, PsyVector *other);
 
-gboolean
+G_MODULE_EXPORT gboolean
 psy_vector_equals(PsyVector *self, PsyVector *other);
-gboolean
+
+G_MODULE_EXPORT gboolean
 psy_vector_not_equals(PsyVector *self, PsyVector *other);
 
 G_END_DECLS

--- a/psy/psy-vector3.h
+++ b/psy/psy-vector3.h
@@ -8,6 +8,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_VECTOR3 psy_vector3_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyVector3, psy_vector3, PSY, VECTOR3, GObject)
 
 G_MODULE_EXPORT PsyVector3 *

--- a/psy/psy-vector4.h
+++ b/psy/psy-vector4.h
@@ -12,6 +12,8 @@ typedef struct _PsyMatrix4 PsyMatrix4;
 G_BEGIN_DECLS
 
 #define PSY_TYPE_VECTOR4 psy_vector4_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyVector4, psy_vector4, PSY, VECTOR4, GObject)
 
 G_MODULE_EXPORT PsyVector4 *

--- a/psy/psy-visual-stimulus.h
+++ b/psy/psy-visual-stimulus.h
@@ -18,6 +18,8 @@ struct _PsyArtist;
 typedef struct _PsyArtist PsyArtist;
 
 #define PSY_TYPE_VISUAL_STIMULUS psy_visual_stimulus_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(
     PsyVisualStimulus, psy_visual_stimulus, PSY, VISUAL_STIMULUS, PsyStimulus)
 

--- a/psy/psy-wave.h
+++ b/psy/psy-wave.h
@@ -9,6 +9,7 @@ G_BEGIN_DECLS
 
 #define PSY_TYPE_WAVE psy_wave_get_type()
 
+G_MODULE_EXPORT
 G_DECLARE_FINAL_TYPE(PsyWave, psy_wave, PSY, WAVE, PsyGstStimulus)
 
 G_MODULE_EXPORT PsyWave *

--- a/psy/psy-window.h
+++ b/psy/psy-window.h
@@ -7,6 +7,8 @@
 G_BEGIN_DECLS
 
 #define PSY_TYPE_WINDOW psy_window_get_type()
+
+G_MODULE_EXPORT
 G_DECLARE_DERIVABLE_TYPE(PsyWindow, psy_window, PSY, WINDOW, PsyCanvas)
 
 /**


### PR DESCRIPTION
This merge request enforces that psylib is compiled with gnu_symbol_visibility=hidden.

this fixes #109 