### PR TITLE
Fix PsyTeensyTrigger.Open

### DIFF
--- a/psy/hw/psy-serial-port.c
+++ b/psy/hw/psy-serial-port.c
@@ -145,12 +145,13 @@ serial_port_finalize(GObject *obj)
     psy_duration_free(priv->timeout);
 }
 
-static void
+static gboolean
 serial_port_open(PsySerialPort *self, GError **error)
 {
     (void) error;
     PsySerialPortPrivate *priv = psy_serial_port_get_instance_private(self);
     priv->is_open              = 1;
+    return TRUE;
 }
 
 static void
@@ -320,17 +321,19 @@ psy_serial_port_free(PsySerialPort *self)
  *
  * Opens the device with the, make sure you have set the port name, the
  * device file is backed by the actual device.
+ *
+ * Returns: TRUE if the serial port is opened, false otherwise
  */
-void
+gboolean
 psy_serial_port_open(PsySerialPort *self, GError **error)
 {
-    g_return_if_fail(PSY_IS_SERIAL_PORT(self));
-    g_return_if_fail(error == NULL || *error == NULL);
+    g_return_val_if_fail(PSY_IS_SERIAL_PORT(self), FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     PsySerialPortClass *klass = PSY_SERIAL_PORT_GET_CLASS(self);
-    g_return_if_fail(klass->open != NULL);
+    g_return_val_if_fail(klass->open != NULL, FALSE);
 
-    klass->open(self, error);
+    return klass->open(self, error);
 }
 
 /**

--- a/psy/hw/psy-serial-port.h
+++ b/psy/hw/psy-serial-port.h
@@ -36,7 +36,7 @@ G_DECLARE_DERIVABLE_TYPE(
 typedef struct _PsySerialPortClass {
     GObjectClass parent_class;
 
-    void (*open)(PsySerialPort *self, GError **error);
+    gboolean (*open)(PsySerialPort *self, GError **error);
     void (*close)(PsySerialPort *self);
 
     void (*set_port_name)(PsySerialPort *self, const gchar *name);
@@ -73,7 +73,7 @@ psy_serial_port_set_name(PsySerialPort *self, const gchar *name);
 G_MODULE_EXPORT const char *
 psy_serial_port_get_name(PsySerialPort *self);
 
-G_MODULE_EXPORT void
+G_MODULE_EXPORT gboolean
 psy_serial_port_open(PsySerialPort *self, GError **error);
 
 G_MODULE_EXPORT void

--- a/psy/hw/psy-teensy-trigger.c
+++ b/psy/hw/psy-teensy-trigger.c
@@ -220,21 +220,31 @@ teensy_trigger_get_property(GObject    *object,
     }
 }
 
-static void
+static gboolean
 teensy_trigger_open(PsyTeensyTrigger *self, GError **error)
 {
-    psy_serial_port_open(self->port, error);
-    TeensyMsg msg = teensy_msg_create_connect();
+    gboolean ret = psy_serial_port_open(self->port, error);
+    if (ret) {
+        TeensyMsg msg = teensy_msg_create_connect();
 
-    serial_port_write_msg(self->port, &msg, error);
+        serial_port_write_msg(self->port, &msg, error);
 
-    msg = serial_port_read_msg(self->port);
-    if (msg.buffer[0] != 2 || msg.buffer[1] != ACK) {
-        // It's not a teensy trigger
-        g_critical("Not communicating to a device that is a teensy trigger, "
-                   "did you set the proper device_name");
-        psy_serial_port_close(self->port);
+        msg = serial_port_read_msg(self->port);
+        if (msg.buffer[0] != 2 || msg.buffer[1] != ACK) {
+            // It's not a teensy trigger
+            g_critical(
+                "Not communicating to a device that is a teensy trigger, "
+                "did you set the proper device_name");
+            g_set_error(
+                error,
+                PSY_SERIAL_PORT_ERROR,
+                PSY_SERIAL_PORT_ERROR_FAILED,
+                "Connected device doesn't respond like a TeensyTrigger");
+            psy_serial_port_close(self->port);
+        }
+        ret = FALSE;
     }
+    return ret;
 }
 
 static void
@@ -355,19 +365,19 @@ psy_teensy_trigger_new(const gchar *name)
  * device. This should be called before trying to trigger. This or the
  * _async version should be called and completed before trying to write
  * triggers.
+ *
+ * Returns: TRUE when the device is successfully opened, FALSE otherwise.
  */
-void
+gboolean
 psy_teensy_trigger_open(PsyTeensyTrigger *self, GError **error)
 {
-    g_return_if_fail(PSY_IS_TEENSY_TRIGGER(self));
-    g_return_if_fail(error || *error != NULL);
+    g_return_val_if_fail(PSY_IS_TEENSY_TRIGGER(self), FALSE);
+    g_return_val_if_fail(error || *error != NULL, FALSE);
 
     if (psy_serial_port_get_is_open(self->port))
-        return;
+        return TRUE;
 
-    teensy_trigger_open(self, error);
-
-    return;
+    return teensy_trigger_open(self, error);
 }
 
 /**

--- a/psy/hw/psy-teensy-trigger.h
+++ b/psy/hw/psy-teensy-trigger.h
@@ -18,7 +18,7 @@ G_DECLARE_FINAL_TYPE(
 G_MODULE_EXPORT PsyTeensyTrigger *
 psy_teensy_trigger_new(const gchar *name);
 
-G_MODULE_EXPORT void
+G_MODULE_EXPORT gboolean
 psy_teensy_trigger_open(PsyTeensyTrigger *self, GError **error);
 
 G_MODULE_EXPORT void

--- a/psy/hw/psy-termios.c
+++ b/psy/hw/psy-termios.c
@@ -99,7 +99,7 @@ psy_termios_init(PsyTermios *self)
  * hasn't touched the device. Then it sets the serial it tries to open the
  * serial port.
  */
-static void
+static gboolean
 termios_open(PsySerialPort *self, GError **error)
 {
     PsyTermios *termios_self = PSY_TERMIOS(self);
@@ -131,7 +131,7 @@ termios_open(PsySerialPort *self, GError **error)
                         "Unable to open device: %s",
                         g_strerror(errno));
         }
-        return;
+        return FALSE;
     }
 
     if (tcgetattr(termios_self->fd, &termios_self->existing_config) < 0
@@ -154,7 +154,7 @@ termios_open(PsySerialPort *self, GError **error)
                     PSY_SERIAL_PORT_ERROR_FAILED,
                     "Unable to set baudrate: %s",
                     g_strerror(errno));
-        return;
+        goto failure;
     }
 
     // Set desired timeout
@@ -175,16 +175,16 @@ termios_open(PsySerialPort *self, GError **error)
                     PSY_SERIAL_PORT_ERROR_FAILED,
                     "Unable to set the new serial port settings: %s",
                     g_strerror(errno));
+        goto failure;
     }
 
-    PSY_SERIAL_PORT_CLASS(psy_termios_parent_class)->open(self, error);
-
-    return;
+    return PSY_SERIAL_PORT_CLASS(psy_termios_parent_class)->open(self, error);
 
 failure:
 
     close(termios_self->fd);
     termios_self->fd = -1;
+    return FALSE;
 }
 
 static void


### PR DESCRIPTION
Makes the serial port.open return TRUE or FALSE depending on a successful open of a serial port. If insuccesfull, this is reflected in TeensyTriggers.open and an error is returned instead of rolling in an infinite loop

fixes #146