### PR TITLE
Fix/timer cancellation no loop

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 *.c text eol=lf
 *.h text eol=lf
 *.cpp text eol=lf
+
+meson.build text eol=lf

--- a/psy/psy-timer-private.c
+++ b/psy/psy-timer-private.c
@@ -175,10 +175,9 @@ psy_timer_thread_del_timer(PsyTimerThread *self, PsyTimer *timer)
 {
     GAsyncQueue *reply_queue = psy_timer_get_queue(timer);
 
+    // When this function is called after the timer has already
+    // fired. It's not an error.
     gboolean ret = g_ptr_array_remove(self->timers, timer);
-    if (!ret) {
-        g_critical("Unable to remove timer %p", (gpointer) timer);
-    }
 
     ThreadData *msg = thread_data_new(
         ret ? MSG_TIMER_CANCELED : MSG_TIMER_NO_SUCH_TIMER, self, timer);
@@ -429,8 +428,8 @@ timer_private_cancel_timer(PsyTimer *timer)
     }
     else {
         if (G_UNLIKELY(result->msg != MSG_TIMER_CANCELED)) {
+            // Apparently the timer has already fired
             g_assert(result->msg == MSG_TIMER_NO_SUCH_TIMER);
-            g_warning("No such timer: %p", (gpointer) result->timer);
         }
 
         g_free(result);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -79,6 +79,19 @@ endif
 test('test-timer', test_timer, is_parallel:false, args: test_timer_args)
 
 
+timer_cancellation_no_loop = executable(
+    'timer-cancellation-no-loop',
+    'timer-cancellation-no-loop.c',
+    dependencies: [psy_dep],
+    c_args: UNIT_PP_ARGS,
+    cpp_args: UNIT_PP_ARGS,
+)
+env = environment({'G_DEBUG':'fatal-warnings'})
+test(
+    'timer-cancellation-no-loop',
+    timer_cancellation_no_loop,
+    env:env
+)
 
 unit_test = executable (
     'unit-test',

--- a/tests/python-triggers.py
+++ b/tests/python-triggers.py
@@ -16,22 +16,24 @@ timer_dur = Psy.Duration.new_ms(100)
 isi = Psy.Duration.new_ms(50)  # onset of trigger after timer has fired
 trigger_dur = Psy.Duration.new_ms(1)
 
-class RangedInt:
 
+class RangedInt:
     def __init__(self, min, max):
         if min >= max:
             raise ValueError("min should be smaller than max")
         self.min = min
         self.max = max
-    
+
     def __call__(self, value):
         ival = int(value)
 
         if self.min <= ival < self.max:
             return ival
         else:
-            raise ap.ArgumentTypeError(f"{value} is not an int in the range [{self.min}, {self.max})")
-    
+            raise ap.ArgumentTypeError(
+                f"{value} is not an int in the range [{self.min}, {self.max})"
+            )
+
     def __repr__(self):
         return f"RangedInt({self.min}, {self.max})"
 
@@ -47,7 +49,8 @@ def on_timer_fire(
     parallel: Psy.ParallelTrigger,
 ):
     teensy.write(0xFF, tp.add(isi))
-    parallel.write(0xFF, tp.add(isi), trigger_dur)
+    if parallel.props.is_open:
+        parallel.write(0xFF, tp.add(isi), trigger_dur)
 
     timer.set_fire_time(tp.add(timer_dur))
 
@@ -58,6 +61,7 @@ def main() -> None:
     parser = ap.ArgumentParser(sys.argv[0], description="trigger a teensy device")
     parser.add_argument("-s", "--serial_name", type=str, default=SERIAL_DEV)
     parser.add_argument("-t", "--trigdur", type=RangedInt(1, 50), default=1)
+    parser.add_argument("--no-parallel", action="store_true")
 
     args = parser.parse_args()
     if args.trigdur:
@@ -71,7 +75,9 @@ def main() -> None:
 
     teensy.open()
     teensy.set_trig_dur(trigger_dur)
-    parallel.open(0)
+
+    if not args.no_parallel:
+        parallel.open(0)
 
     timer = Psy.Timer()
     print(timer)

--- a/tests/timer-cancellation-no-loop.c
+++ b/tests/timer-cancellation-no-loop.c
@@ -24,6 +24,8 @@ main()
     g_signal_connect(timer, "fired", G_CALLBACK(dont_fire), NULL);
     g_object_set(timer, "fire-time", tp_now, NULL);
 
+    g_usleep(10000); // 10ms
+
     psy_time_point_free(tp_now);
     psy_timer_free(timer);
     psy_clock_free(clk);

--- a/tests/timer-cancellation-no-loop.c
+++ b/tests/timer-cancellation-no-loop.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <psylib.h>
+
+static void
+dont_fire(PsyTimer *timer, PsyTimePoint *tp)
+{
+    (void) timer;
+    (void) tp;
+    assert(1 == 0); // shouldn't be called as no loop is running
+}
+
+int
+main()
+{
+    PsyInitializer *init = g_object_new(
+        PSY_TYPE_INITIALIZER, "gstreamer", FALSE, "portaudio", FALSE, NULL);
+
+    PsyClock     *clk    = psy_clock_new();
+    PsyTimer     *timer  = psy_timer_new();
+    PsyTimePoint *tp_now = psy_clock_now(clk);
+
+    g_print("timer = %p\n", (void *) timer);
+
+    g_signal_connect(timer, "fired", G_CALLBACK(dont_fire), NULL);
+    g_object_set(timer, "fire-time", tp_now, NULL);
+
+    psy_time_point_free(tp_now);
+    psy_timer_free(timer);
+    psy_clock_free(clk);
+    g_object_unref(init);
+}


### PR DESCRIPTION
Currently adds a test that checks whether it is able to cancel a timer when no GMainLoop is running.
The fix must still be added..